### PR TITLE
Python 3.11 support

### DIFF
--- a/gempy_engine/core/data/exported_fields.py
+++ b/gempy_engine/core/data/exported_fields.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
 import numpy as np
@@ -13,7 +13,7 @@ class ExportedFields:
     _gz_field: Optional[np.ndarray] = None
     
     _n_points_per_surface: Optional[np.ndarray] = None
-    _slice_feature: Optional[slice] = slice(None, None)  # Slice all the surface points
+    _slice_feature: Optional[slice] = field(default_factory=lambda: slice(None, None))  # Slice all the surface points
     _grid_size: Optional[int] = None
     
     _scalar_field_at_surface_points: Optional[np.ndarray] = None

--- a/gempy_engine/core/data/kernel_classes/surface_points.py
+++ b/gempy_engine/core/data/kernel_classes/surface_points.py
@@ -16,7 +16,7 @@ class SurfacePoints:
     nugget_effect_scalar: Union[np.ndarray, float] = 0.000001
 
     # TODO (Sep 2022): Pretty sure this has to be private
-    slice_feature: Optional[slice] = slice(None, None)  # * Used to slice the surface points values of the interpolation (grid.values)
+    slice_feature: Optional[slice] = field(default_factory=lambda: slice(None, None))  # * Used to slice the surface points values of the interpolation (grid.values)
 
     def __post_init__(self):
         if type(self.nugget_effect_scalar) is float or type(self.nugget_effect_scalar) is int:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
     ],
     python_requires=">=3.10",
     install_requires=read_requirements("requirements/requirements.txt"),


### PR DESCRIPTION
- Fixes importing gempy_engine in Python 3.11 
    Previously when importing e.g. this error was raised:
        ```
        dataclasses.py", line 815, in _get_field
            raise ValueError(f'mutable default {type(f.default)} for field '
        ValueError: mutable default <class 'slice'> for field slice_feature is not allowed: use default_factory
        import dataclasses
        ```
- Lists Python 3.11 and 3.12 in `setup.py`