### PR TITLE
[ENH] Convert InterpolationOptions to Pydantic model

### DIFF
--- a/gempy_engine/API/server/main_server_pro.py
+++ b/gempy_engine/API/server/main_server_pro.py
@@ -27,7 +27,7 @@ logger = setup_logger()
 
 # Default interpolation options
 range_ = 1
-default_interpolation_options: InterpolationOptions = InterpolationOptions(
+default_interpolation_options: InterpolationOptions = InterpolationOptions.from_args(
     range=range_,
     c_o=(range_ ** 2) / 14 / 3,
     number_octree_levels=4,

--- a/gempy_engine/core/data/options/evaluation_options.py
+++ b/gempy_engine/core/data/options/evaluation_options.py
@@ -14,7 +14,7 @@ class MeshExtractionMaskingOptions(enum.Enum):
 class EvaluationOptions:
     _number_octree_levels: int = 1
     _number_octree_levels_surface: int = 4
-    octree_curvature_threshold: float = -1  #: Threshold to do octree refinement due to curvature to deal with angular geometries. This curvature assumes that 1 is the maximum curvature of any voxel
+    octree_curvature_threshold: float = -1.  #: Threshold to do octree refinement due to curvature to deal with angular geometries. This curvature assumes that 1 is the maximum curvature of any voxel
     octree_error_threshold: float = 1.  #: Number of standard deviations to consider a voxel as candidate to refine
     octree_min_level: int = 2
     

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -43,6 +43,9 @@ class InterpolationOptions(BaseModel):
         default_factory=TempInterpolationValues,
         exclude=True
     )
+    
+    def __init__(self):
+        pass
 
     # endregion
 
@@ -90,7 +93,7 @@ class InterpolationOptions(BaseModel):
         block_solutions_type = RawArraysSolution.BlockSolutionType.OCTREE
         sigmoid_slope = 5_000_000
 
-        return InterpolationOptions(
+        return InterpolationOptions.from_args(
             kernel_options=kernel_options,
             evaluation_options=evaluation_options,
             # temp_interpolation_values=temp_interpolation_values,
@@ -106,7 +109,7 @@ class InterpolationOptions(BaseModel):
 
     @classmethod
     def init_octree_options(cls, range=1.7, c_o=10, refinement: int = 1):
-        return InterpolationOptions(
+        return InterpolationOptions.from_args(
             range=range,
             c_o=c_o,
             mesh_extraction=True,
@@ -115,7 +118,7 @@ class InterpolationOptions(BaseModel):
 
     @classmethod
     def init_dense_grid_options(cls):
-        options = InterpolationOptions(
+        options = InterpolationOptions.from_args(
             range=1.7,
             c_o=10,
             mesh_extraction=False,
@@ -130,7 +133,7 @@ class InterpolationOptions(BaseModel):
         raise NotImplementedError("Probabilistic interpolation is not yet implemented.")
 
     # def __repr__(self):
-    #     return f"InterpolationOptions({', '.join(f'{k}={v}' for k, v in asdict(self).items())})"
+    #     return f"InterpolationOptions.from_args({', '.join(f'{k}={v}' for k, v in asdict(self).items())})"
 
     # def _repr_html_(self):
     #     html = f"""

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -43,10 +43,7 @@ class InterpolationOptions(BaseModel):
         default_factory=TempInterpolationValues,
         exclude=True
     )
-    
-    def __init__(self):
-        pass
-
+   
     # endregion
 
     @classmethod

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -23,13 +23,14 @@ class InterpolationOptions(BaseModel):
         arbitrary_types_allowed=False,
         use_enum_values=False,
         json_encoders={
-                CacheMode: lambda e: e.value
+                CacheMode: lambda e: e.value,
+                AvailableKernelFunctions: lambda e: e.name
         }
     )
 
     # @off
-    kernel_options: KernelOptions = Field(init=True)  # * This is the compression of the fields above and the way to go in the future
-    evaluation_options: EvaluationOptions = Field(init=True)
+    kernel_options: KernelOptions = Field(init=True, exclude=False)  # * This is the compression of the fields above and the way to go in the future
+    evaluation_options: EvaluationOptions = Field(init=True, exclude= False)
 
     debug: bool
     cache_mode: CacheMode

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -90,7 +90,7 @@ class InterpolationOptions(BaseModel):
         block_solutions_type = RawArraysSolution.BlockSolutionType.OCTREE
         sigmoid_slope = 5_000_000
 
-        return InterpolationOptions.from_args(
+        return InterpolationOptions(
             kernel_options=kernel_options,
             evaluation_options=evaluation_options,
             # temp_interpolation_values=temp_interpolation_values,

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -39,7 +39,10 @@ class InterpolationOptions(BaseModel):
     debug_water_tight: bool = False
 
     # region Volatile
-    _temp_interpolation_values: TempInterpolationValues = PrivateAttr(default_factory=TempInterpolationValues)
+    temp_interpolation_values: TempInterpolationValues = Field(
+        default_factory=TempInterpolationValues,
+        exclude=True
+    )
 
     # endregion
 
@@ -165,10 +168,6 @@ class InterpolationOptions(BaseModel):
                 setattr(self, key, value)  # sets the attribute to the provided value
             else:
                 warnings.warn(f"{key} is not a recognized attribute and will be ignored.")
-
-    @property
-    def temp_interpolation_values(self):
-        return self._temp_interpolation_values
 
     @property
     def number_octree_levels(self):

--- a/gempy_engine/core/data/options/kernel_options.py
+++ b/gempy_engine/core/data/options/kernel_options.py
@@ -1,6 +1,7 @@
 import warnings
 
 from dataclasses import dataclass, asdict
+from typing import Optional
 
 from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
 from gempy_engine.core.data.kernel_classes.solvers import Solvers
@@ -8,7 +9,7 @@ from gempy_engine.core.data.kernel_classes.solvers import Solvers
 
 @dataclass(frozen=False)
 class KernelOptions:
-    range: int  # TODO: have constructor from RegularGrid
+    range: int | float # TODO: have constructor from RegularGrid
     c_o: float  # TODO: This should be a property
     uni_degree: int = 1
     i_res: float = 4.
@@ -20,7 +21,7 @@ class KernelOptions:
 
     compute_condition_number: bool = False
     optimizing_condition_number: bool = False
-    condition_number: float = None
+    condition_number: Optional[float] = None
 
     @property
     def n_uni_eq(self):

--- a/gempy_engine/core/data/options/kernel_options.py
+++ b/gempy_engine/core/data/options/kernel_options.py
@@ -3,13 +3,15 @@ import warnings
 from dataclasses import dataclass, asdict
 from typing import Optional
 
+from pydantic import field_validator
+
 from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
 from gempy_engine.core.data.kernel_classes.solvers import Solvers
 
 
 @dataclass(frozen=False)
 class KernelOptions:
-    range: int | float # TODO: have constructor from RegularGrid
+    range: int | float  # TODO: have constructor from RegularGrid
     c_o: float  # TODO: This should be a property
     uni_degree: int = 1
     i_res: float = 4.
@@ -22,6 +24,24 @@ class KernelOptions:
     compute_condition_number: bool = False
     optimizing_condition_number: bool = False
     condition_number: Optional[float] = None
+
+    @field_validator('kernel_function', mode='before')
+    @classmethod
+    def _deserialize_kernel_function_from_name(cls, value):
+        """
+        Ensures that a string input (e.g., "cubic" from JSON)
+        is correctly converted to an AvailableKernelFunctions enum member.
+        """
+        if isinstance(value, str):
+            try:
+                return AvailableKernelFunctions[value]  # Lookup enum member by name
+            except KeyError:
+                # This provides a more specific error if the name doesn't exist
+                valid_names = [member.name for member in AvailableKernelFunctions]
+                raise ValueError(f"Invalid kernel function name '{value}'. Must be one of: {valid_names}")
+        # If it's already an AvailableKernelFunctions member (e.g., during direct model instantiation),
+        # or if it's another type that Pydantic's later validation will catch as an error.
+        return value
 
     @property
     def n_uni_eq(self):
@@ -66,16 +86,16 @@ class KernelOptions:
     def __hash__(self):
         # Using a tuple to hash all the values together
         return hash((
-            self.range,
-            self.c_o,
-            self.uni_degree,
-            self.i_res,
-            self.gi_res,
-            self.number_dimensions,
-            self.kernel_function,
-            self.compute_condition_number,
+                self.range,
+                self.c_o,
+                self.uni_degree,
+                self.i_res,
+                self.gi_res,
+                self.number_dimensions,
+                self.kernel_function,
+                self.compute_condition_number,
         ))
-    
+
     def __repr__(self):
         return f"KernelOptions({', '.join(f'{k}={v}' for k, v in asdict(self).items())})"
 

--- a/gempy_engine/core/data/options/temp_interpolation_values.py
+++ b/gempy_engine/core/data/options/temp_interpolation_values.py
@@ -1,2 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
 class TempInterpolationValues:
     current_octree_level: int = 0  # * Make this a read only property 

--- a/gempy_engine/modules/kernel_constructor/_pykeops_cov_compiler.py
+++ b/gempy_engine/modules/kernel_constructor/_pykeops_cov_compiler.py
@@ -40,7 +40,7 @@ def simple_model_2():
     ori_i = Orientations(dip_positions, nugget_effect_grad)
 
     range = 5 ** 2
-    kri = InterpolationOptions(range, 1, 0, i_res=1, gi_res=1,
+    kri = InterpolationOptions.from_args(range, 1, 0, i_res=1, gi_res=1,
                                number_dimensions=2)
 
     _ = np.ones(3)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+pydantic
 python-dotenv

--- a/tests/benchmark/one_fault_model.py
+++ b/tests/benchmark/one_fault_model.py
@@ -93,7 +93,7 @@ def one_fault_model():
     range_ = 7 ** 2  # ? Since we are not getting the square root should we also square this? 
     c_o = 1
 
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range_, c_o,
         uni_degree=1,
         number_dimensions=3,

--- a/tests/fixtures/complex_geometries.py
+++ b/tests/fixtures/complex_geometries.py
@@ -77,7 +77,7 @@ def one_fault_model():
     range_ = 7 ** 2  # ? Since we are not getting the square root should we also square this? 
     c_o = 1
 
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range_, c_o,
         uni_degree=1,
         number_dimensions=3,
@@ -144,7 +144,7 @@ def one_finite_fault_model():
     range_ = 7 ** 2  # ? Since we are not getting the square root should we also square this? 
     c_o = 1
 
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range_, c_o,
         uni_degree=1,
         number_dimensions=3,
@@ -211,7 +211,7 @@ def graben_fault_model():
     range_ = 7 ** 2  # ? Since we are not getting the square root should we also square this? 
     c_o = 1
 
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range_, c_o,
         uni_degree=1,
         number_dimensions=3,

--- a/tests/fixtures/heavy_models.py
+++ b/tests/fixtures/heavy_models.py
@@ -102,7 +102,7 @@ def moureze_model_factory(path_to_root: str, pick_every=8, octree_lvls=3, solver
     # endregion
 
     # region InterpolationOptions
-    interpolation_options: InterpolationOptions = InterpolationOptions(
+    interpolation_options: InterpolationOptions = InterpolationOptions.from_args(
         range=100.,
         c_o=10.,
         number_octree_levels=octree_lvls,

--- a/tests/fixtures/simple_geometries.py
+++ b/tests/fixtures/simple_geometries.py
@@ -46,7 +46,7 @@ def unconformity() -> Tuple[InterpolationInput, InterpolationOptions, InputDataD
     i_r = 4
     gi_r = 2
 
-    options = InterpolationOptions(range_, c_o, uni_degree=1, i_res=i_r, gi_res=gi_r,
+    options = InterpolationOptions.from_args(range_, c_o, uni_degree=1, i_res=i_r, gi_res=gi_r,
                                    number_dimensions=3,
                                    kernel_function=AvailableKernelFunctions.cubic)
 

--- a/tests/fixtures/simple_models.py
+++ b/tests/fixtures/simple_models.py
@@ -56,7 +56,7 @@ def simple_model_2_factory() -> Tuple[SurfacePoints, Orientations, Interpolation
                               [0, .8]])
     nugget_effect_grad = 0.0000001
     ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
-    kri = InterpolationOptions(5, 5 ** 2 / 14 / 3, 0,
+    kri = InterpolationOptions.from_args(5, 5 ** 2 / 14 / 3, 0,
                                number_dimensions=2, kernel_function=AvailableKernelFunctions.cubic)
     tensor_struct = TensorsStructure(number_of_points_per_surface=np.array([4, 3]))
     stack_structure = StacksStructure(number_of_points_per_stack=np.array([7]),
@@ -113,7 +113,7 @@ def simple_model() -> Tuple[SurfacePoints, Orientations, InterpolationOptions, I
         range_ = 4.166666666667
         co = 0.1428571429
         ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
-        kri = InterpolationOptions(
+        kri = InterpolationOptions.from_args(
             range_,
             co,
             0,
@@ -163,7 +163,7 @@ def simple_model_interpolation_input_factory():
     range_ = 4.166666666667
     co = 0.1428571429
     ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
-    interpolation_options = InterpolationOptions(range_, co, 0, number_dimensions=3,
+    interpolation_options = InterpolationOptions.from_args(range_, co, 0, number_dimensions=3,
                                                  kernel_function=AvailableKernelFunctions.cubic)
     ids = np.array([1, 2])
     interpolation_input = InterpolationInput(spi, ori_i, grid_0_centers, ids)
@@ -217,7 +217,7 @@ def _gen_simple_model_3_layers(simple_grid_3d_octree):
     range_ = 4.166666666667
     co = 0.1428571429
     ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
-    interpolation_options = InterpolationOptions(range_, co, 0, i_res=4, gi_res=2,
+    interpolation_options = InterpolationOptions.from_args(range_, co, 0, i_res=4, gi_res=2,
                                                  number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
     tensor_structure = TensorsStructure(number_of_points_per_surface=np.array([7, 2, 2]))
     stack_structure = StacksStructure(number_of_points_per_stack=np.array([11]),
@@ -267,7 +267,7 @@ def simple_model_3_layers_high_res(simple_grid_3d_more_points_grid) -> Tuple[Int
 
     ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
 
-    interpolation_options = InterpolationOptions(range_, co, 0,
+    interpolation_options = InterpolationOptions.from_args(range_, co, 0,
                                                  number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
 
     ids = np.array([1, 2, 3, 4])
@@ -386,7 +386,7 @@ def unconformity_complex_factory():
     c_o = 35.71428571 * 100
     i_r = 4
     gi_r = 2
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range_, c_o, uni_degree=0, i_res=i_r, gi_res=gi_r,
         number_dimensions=3,
         kernel_function=AvailableKernelFunctions.cubic)
@@ -439,7 +439,7 @@ def unconformity_complex_implicit():
     i_r = 4
     gi_r = 2
 
-    options = InterpolationOptions(range_, c_o, uni_degree=0, i_res=i_r, gi_res=gi_r,
+    options = InterpolationOptions.from_args(range_, c_o, uni_degree=0, i_res=i_r, gi_res=gi_r,
                                    number_dimensions=3,
                                    kernel_function=AvailableKernelFunctions.cubic)
 
@@ -477,7 +477,7 @@ def unconformity_complex_one_layer():
     i_r = 4
     gi_r = 2
 
-    options = InterpolationOptions(range_, c_o, uni_degree=0, i_res=i_r, gi_res=gi_r,
+    options = InterpolationOptions.from_args(range_, c_o, uni_degree=0, i_res=i_r, gi_res=gi_r,
                                    number_dimensions=3,
                                    kernel_function=AvailableKernelFunctions.cubic)
 

--- a/tests/test_common/test_api/test_public_interface.py
+++ b/tests/test_common/test_api/test_public_interface.py
@@ -60,7 +60,7 @@ def test_public_interface_simplest_model():
 
     # region InterpolationOptions
 
-    interpolation_options: InterpolationOptions = InterpolationOptions(
+    interpolation_options: InterpolationOptions = InterpolationOptions.from_args(
         range=4.166666666667,  # TODO: have constructor from RegularGrid
         c_o=0.1428571429,  # TODO: This should be a property
         number_octree_levels=3,

--- a/tests/test_common/test_integrations/test_kernels.py
+++ b/tests/test_common/test_integrations/test_kernels.py
@@ -7,7 +7,7 @@ from tests.fixtures.simple_models import simple_model_interpolation_input_factor
 
 def test_interpolate_model_cubic(n_oct_levels=3):
     interpolation_input, options, structure = simple_model_interpolation_input_factory()
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range=options.range,
         c_o=options.c_o,
         uni_degree=0,
@@ -31,7 +31,7 @@ def test_interpolate_model_cubic(n_oct_levels=3):
 def test_interpolate_model_exponential(n_oct_levels=3):
     interpolation_input, options, structure = simple_model_interpolation_input_factory()
 
-    options = InterpolationOptions(
+    options = InterpolationOptions.from_args(
         range=options.range,
         c_o=options.c_o,
         uni_degree=0,

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
@@ -94,7 +94,7 @@ class TestPykeopsNumPyEqual():
         input_data_descriptor: InputDataDescriptor = simple_model_2_b[3]
 
         # Prepare options
-        interpolation_options = InterpolationOptions(
+        interpolation_options = InterpolationOptions.from_args(
             range=5,
             c_o=5 ** 2 / 14 / 3,
             uni_degree=0,

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor_2.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor_2.py
@@ -69,7 +69,7 @@ class TestCompareWithGempy_v2:
         tensors_structure = simple_model[3]
 
         # Prepare options
-        interpolation_options = InterpolationOptions(
+        interpolation_options = InterpolationOptions.from_args(
             range=5,
             c_o=5 ** 2 / 14 / 3,
             uni_degree=0,

--- a/tests/test_pytorch/test_pytorch_gradients.py
+++ b/tests/test_pytorch/test_pytorch_gradients.py
@@ -64,7 +64,7 @@ def simple_model_interpolation_input_TORCH():
     co = 0.1428571429
 
     ori_i = Orientations(dip_positions, dip_gradients, nugget_effect_grad)
-    interpolation_options = InterpolationOptions(range_, co, 0, number_dimensions=3,
+    interpolation_options = InterpolationOptions.from_args(range_, co, 0, number_dimensions=3,
                                                  kernel_function=AvailableKernelFunctions.cubic)
     ids = np.array([1, 2])
     interpolation_input = InterpolationInput(spi, ori_i, grid_0_centers, ids)


### PR DESCRIPTION
# Getting the first example of InterpolationOptions serializable

This PR converts the `InterpolationOptions` class from a dataclass to a Pydantic model to enable serialization. The changes include:

- Replaced dataclass with Pydantic's `BaseModel` for `InterpolationOptions`
- Converted the constructor to a class method `from_args()` to maintain backward compatibility
- Added proper type annotations and Pydantic Field definitions
- Fixed a minor type issue in `octree_curvature_threshold` by adding a decimal point
- Added proper model configuration for enum handling
- Made `TempInterpolationValues` a proper dataclass

These changes are the first step toward making the model serializable while maintaining the existing functionality.