### PR TITLE
[ENH] Add numpy array validator and fix type annotations

### DIFF
--- a/gempy_engine/core/data/encoders/converters.py
+++ b/gempy_engine/core/data/encoders/converters.py
@@ -1,0 +1,4 @@
+import numpy as np
+from pydantic import BeforeValidator
+
+numpy_array_short_validator = BeforeValidator(lambda v: np.array(v) if v is not None else None)

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -106,7 +106,7 @@ class InterpolationOptions(BaseModel):
     # @on
 
     @classmethod
-    def init_octree_options(cls, range=1.7, c_o=10, refinement: int = 1):
+    def init_octree_options(cls, range=1.7, c_o=10., refinement: int = 1):
         return InterpolationOptions.from_args(
             range=range,
             c_o=c_o,
@@ -118,7 +118,7 @@ class InterpolationOptions(BaseModel):
     def init_dense_grid_options(cls):
         options = InterpolationOptions.from_args(
             range=1.7,
-            c_o=10,
+            c_o=10.,
             mesh_extraction=False,
             number_octree_levels=1
         )

--- a/gempy_engine/core/data/options/kernel_options.py
+++ b/gempy_engine/core/data/options/kernel_options.py
@@ -25,7 +25,8 @@ class KernelOptions:
     optimizing_condition_number: bool = False
     condition_number: Optional[float] = None
 
-    @field_validator('kernel_function', mode='before')
+
+    @field_validator('kernel_function', mode='before', json_schema_input_type=str)
     @classmethod
     def _deserialize_kernel_function_from_name(cls, value):
         """


### PR DESCRIPTION
# Improved JSON Serialization and Validation for Numpy Arrays

This PR adds proper JSON serialization support for numpy arrays in the Transform class by using Pydantic's Annotated type with a custom validator. The changes include:

- Added a new `encoders` module with a `converters.py` file containing a numpy array validator
- Updated the `Transform` class to use the new validator for position, rotation, and scale properties
- Fixed the `kernel_function` field validator to properly handle JSON schema input
- Updated floating point values in `interpolation_options.py` to use explicit decimal notation

These changes improve the serialization/deserialization process, particularly when working with JSON data.