### PR TITLE
[ENH] Improve type annotations with short_array_type and field defaults

### DIFF
--- a/gempy_engine/core/data/centered_grid.py
+++ b/gempy_engine/core/data/centered_grid.py
@@ -1,14 +1,15 @@
 ﻿from dataclasses import dataclass, field
-from typing import Sequence, Union, Annotated
 
 import numpy as np
-from .encoders.converters import numpy_array_short_validator
+
+from .encoders.converters import short_array_type
+
 
 @dataclass
 class CenteredGrid:
-    centers: Annotated[np.ndarray,  numpy_array_short_validator] #: This is just used to calculate xyz to interpolate. Tz is independent
-    resolution: Annotated[np.ndarray,  numpy_array_short_validator]  
-    radius: float | Annotated[np.ndarray,  numpy_array_short_validator]
+    centers: short_array_type  #: This is just used to calculate xyz to interpolate. Tz is independent
+    resolution: short_array_type  
+    radius: float | short_array_type
 
     kernel_grid_centers: np.ndarray  = field(init=False)
     left_voxel_edges: np.ndarray  = field(init=False)

--- a/gempy_engine/core/data/centered_grid.py
+++ b/gempy_engine/core/data/centered_grid.py
@@ -2,13 +2,13 @@
 from typing import Sequence, Union, Annotated
 
 import numpy as np
-
+from .encoders.converters import numpy_array_short_validator
 
 @dataclass
 class CenteredGrid:
-    centers: np.ndarray  #: This is just used to calculate xyz to interpolate. Tz is independent
-    resolution: Sequence[float] | np.ndarray 
-    radius: float | Sequence[float] | np.ndarray
+    centers: Annotated[np.ndarray,  numpy_array_short_validator] #: This is just used to calculate xyz to interpolate. Tz is independent
+    resolution: Annotated[np.ndarray,  numpy_array_short_validator]  
+    radius: float | Annotated[np.ndarray,  numpy_array_short_validator]
 
     kernel_grid_centers: np.ndarray  = field(init=False)
     left_voxel_edges: np.ndarray  = field(init=False)

--- a/gempy_engine/core/data/centered_grid.py
+++ b/gempy_engine/core/data/centered_grid.py
@@ -1,21 +1,18 @@
-﻿from dataclasses import dataclass
-from typing import Sequence, Union
+﻿from dataclasses import dataclass, field
+from typing import Sequence, Union, Annotated
 
 import numpy as np
-
-from gempy_engine.core.backend_tensor import BackendTensor
-from gempy_engine.core.utils import cast_type_inplace
 
 
 @dataclass
 class CenteredGrid:
     centers: np.ndarray  #: This is just used to calculate xyz to interpolate. Tz is independent
-    resolution: Sequence[float]
-    radius: Union[float, Sequence[float]]
+    resolution: Sequence[float] | np.ndarray 
+    radius: float | Sequence[float] | np.ndarray
 
-    kernel_grid_centers: np.ndarray = None
-    left_voxel_edges: np.ndarray = None
-    right_voxel_edges: np.ndarray = None
+    kernel_grid_centers: np.ndarray  = field(init=False)
+    left_voxel_edges: np.ndarray  = field(init=False)
+    right_voxel_edges: np.ndarray  = field(init=False)
 
     def __len__(self):
         return self.centers.shape[0] * self.kernel_grid_centers.shape[0]

--- a/gempy_engine/core/data/encoders/converters.py
+++ b/gempy_engine/core/data/encoders/converters.py
@@ -1,4 +1,7 @@
+from typing import Annotated
+
 import numpy as np
 from pydantic import BeforeValidator
 
 numpy_array_short_validator = BeforeValidator(lambda v: np.array(v) if v is not None else None)
+short_array_type = Annotated[np.ndarray, numpy_array_short_validator]

--- a/gempy_engine/core/data/geophysics_input.py
+++ b/gempy_engine/core/data/geophysics_input.py
@@ -1,9 +1,12 @@
 ﻿from dataclasses import dataclass
+from typing import Annotated
 
-from ..backend_tensor import BackendTensor
+import numpy as np
+
+from .encoders.converters import numpy_array_short_validator
 
 
 @dataclass
-class GeophysicsInput():
-    tz: BackendTensor.t
-    densities: BackendTensor.t
+class GeophysicsInput:
+    tz: Annotated[np.ndarray,  numpy_array_short_validator]
+    densities: Annotated[np.ndarray,  numpy_array_short_validator]

--- a/gempy_engine/core/data/kernel_classes/faults.py
+++ b/gempy_engine/core/data/kernel_classes/faults.py
@@ -1,22 +1,27 @@
 import dataclasses
-from typing import Optional
+from typing import Optional, Callable
 
 import numpy as np
+from pydantic import Field
 
-from gempy_engine.core.data.transforms import Transform
+from ..encoders.converters import short_array_type
+from ..transforms import Transform
 
 
 @dataclasses.dataclass
 class FiniteFaultData:
-    implicit_function: callable
-    implicit_function_transform: Transform
-    pivot: np.ndarray
-    
+    implicit_function: Callable | None =  Field(exclude=True, default=None)#, default=None)
+    implicit_function_transform: Transform = Field()
+    pivot: short_array_type = Field()
+
     def apply(self, points: np.ndarray) -> np.ndarray:
         transformed_points = self.implicit_function_transform.apply_inverse_with_pivot(
             points=points,
             pivot=self.pivot
         )
+        if self.implicit_function is None:
+            raise ValueError("No implicit function defined. This can happen after deserializing (loading).")
+        
         scalar_block = self.implicit_function(transformed_points)
         return scalar_block 
         
@@ -24,11 +29,11 @@ class FiniteFaultData:
 
 @dataclasses.dataclass
 class FaultsData:
-    fault_values_everywhere: np.ndarray = None
-    fault_values_on_sp: np.ndarray = None
+    fault_values_everywhere: short_array_type | None = None
+    fault_values_on_sp: short_array_type | None = None
     
-    fault_values_ref: np.ndarray = None
-    fault_values_rest: np.ndarray = None
+    fault_values_ref: short_array_type | None = None
+    fault_values_rest: short_array_type | None = None
     
     # User given data:
     thickness: Optional[float] = None

--- a/gempy_engine/core/data/options/interpolation_options.py
+++ b/gempy_engine/core/data/options/interpolation_options.py
@@ -42,7 +42,8 @@ class InterpolationOptions(BaseModel):
     # region Volatile
     temp_interpolation_values: TempInterpolationValues = Field(
         default_factory=TempInterpolationValues,
-        exclude=True
+        exclude=True,
+        repr=False
     )
    
     # endregion


### PR DESCRIPTION
# Improved Type Annotations and Serialization Support

## [CLN] Hide temp_interpolation_values from repr output

Added `repr=False` to `temp_interpolation_values` to prevent it from being displayed in object representations, improving clarity when debugging or logging.

## [ENH] Introduce short_array_type for consistent type annotations

Created a reusable `short_array_type` using `Annotated[np.ndarray, numpy_array_short_validator]` to standardize array validation across the codebase.

## [ENH] Improve CenteredGrid field definitions

- Replaced manual field initialization with `field(init=False)` for cleaner dataclass definition
- Updated type hints to use the new `short_array_type` and modern Python syntax
- Improved type annotations for radius to properly support both float and array types

## [ENH] Enhance FiniteFaultData serialization support

- Added proper field definitions with exclusion for non-serializable callable
- Implemented error handling for deserialized objects with missing implicit functions
- Updated type annotations to use `short_array_type` for consistent validation

## [ENH] Update GeophysicsInput with proper type annotations

Replaced BackendTensor references with properly annotated numpy arrays using the validation system, improving type safety and serialization support.