### PR TITLE
[!!BUG] Chunking with faults were creating rogue voxels | GEN-13299

### DIFF
--- a/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
@@ -86,7 +86,7 @@ def create_scalar_kernel(ki: KernelInput, options: KernelOptions) -> tensor_type
             y_size=j_size,
             n_drift_eq=fault_n,
             drift_start_post_x=cov_size - fault_n,
-            drift_start_post_y=j_size - fault_n
+            drift_start_post_y=j_size
         )
 
         selector = bt.t.sum(selector_components.sel_ui * (selector_components.sel_vj + 1), axis=-1)


### PR DESCRIPTION
### TL;DR

Fixed a bug in the scalar kernel creation by correcting the `drift_start_post_y` parameter.

### What changed?

Modified the `drift_start_post_y` parameter in the `create_scalar_kernel` function by removing the subtraction of `fault_n`. The parameter now uses the full `j_size` value instead of `j_size - fault_n`.

### How to test?

1. Run tests that involve the scalar kernel creation
2. Verify that fault-related calculations work correctly
3. Check that the covariance matrices are properly constructed with the updated parameter

### Why make this change?

The previous implementation incorrectly reduced the `drift_start_post_y` parameter by `fault_n`, which could lead to incorrect selector matrix construction. This fix ensures that the selector components are properly calculated for the full range of the y-dimension, which is critical for accurate fault modeling in the geological simulations.