### PR TITLE
[REFACTOR] Use center grid for dual contouring instead of corners grid

### DIFF
--- a/gempy_engine/API/dual_contouring/_dual_contouring.py
+++ b/gempy_engine/API/dual_contouring/_dual_contouring.py
@@ -49,6 +49,7 @@ def compute_dual_contouring(dc_data_per_stack: DualContouringData, left_right_co
         
         if left_right_codes is None:
             # * Legacy triangulation
+            raise ValueError("Legacy triangulation is deprecated")
             indices = triangulate_dual_contouring(dc_data_per_surface)
         else:
             # * Fancy triangulation 👗

--- a/gempy_engine/API/dual_contouring/_dual_contouring.py
+++ b/gempy_engine/API/dual_contouring/_dual_contouring.py
@@ -49,7 +49,6 @@ def compute_dual_contouring(dc_data_per_stack: DualContouringData, left_right_co
         
         if left_right_codes is None:
             # * Legacy triangulation
-            raise ValueError("Legacy triangulation is deprecated")
             indices = triangulate_dual_contouring(dc_data_per_surface)
         else:
             # * Fancy triangulation 👗

--- a/gempy_engine/API/interp_single/_octree_generation.py
+++ b/gempy_engine/API/interp_single/_octree_generation.py
@@ -17,7 +17,7 @@ from ._multi_scalar_field_manager import interpolate_all_fields
 import numpy as np
 
 
-def interpolate_on_octree(interpolation_input: InterpolationInput, options: InterpolationOptions,
+def interpolate_on_octree_(interpolation_input: InterpolationInput, options: InterpolationOptions,
                           data_shape: InputDataDescriptor) -> OctreeLevel:
     if BackendTensor.engine_backend is not AvailableBackends.PYTORCH and NOT_MAKE_INPUT_DEEP_COPY is False:
         temp_interpolation_input = copy.deepcopy(interpolation_input)
@@ -30,8 +30,9 @@ def interpolate_on_octree(interpolation_input: InterpolationInput, options: Inte
     # * Interpolate - corners
     grid_0_centers: EngineGrid = temp_interpolation_input.grid  # ? This could be moved to the next section
     if options.compute_corners:
-        grid_0_corners: Optional[EngineGrid] = EngineGrid.from_xyz_coords(
-            xyz_coords=_generate_corners(regular_grid=grid_0_centers.octree_grid)
+        xyz_corners = _generate_corners(regular_grid=grid_0_centers.octree_grid)
+        grid_0_corners: EngineGrid = EngineGrid.from_xyz_coords(
+            xyz_coords=xyz_corners
         )
 
         # ! Here we need to swap the grid temporarily but it is
@@ -57,6 +58,64 @@ def interpolate_on_octree(interpolation_input: InterpolationInput, options: Inte
     )
     return next_octree_level
 
+
+def interpolate_on_octree(interpolation_input: InterpolationInput, options: InterpolationOptions,
+                           data_shape: InputDataDescriptor) -> OctreeLevel:
+    if BackendTensor.engine_backend is not AvailableBackends.PYTORCH and NOT_MAKE_INPUT_DEEP_COPY is False:
+        temp_interpolation_input = copy.deepcopy(interpolation_input)
+    else:
+        temp_interpolation_input = interpolation_input
+
+    # * Interpolate - corners
+    if options.compute_corners:
+        grid_0_centers: EngineGrid = temp_interpolation_input.grid  # ? This could be moved to the next section
+        xyz_corners = _generate_corners(regular_grid=grid_0_centers.octree_grid)
+        
+        if grid_0_centers.custom_grid is None:
+            corner_grid = GenericGrid(values=xyz_corners)
+            grid_0_corners = None
+            output_0_corners = []
+            grid_0_centers.corners_grid = corner_grid
+            output_0_centers: List[InterpOutput] = interpolate_all_fields(temp_interpolation_input, options, data_shape)  # interpolate - centers
+            pass   
+        else:
+            # TODO: Here we would like to append the corners to the custom grid
+            raise NotImplementedError("This should not happen")
+      
+        
+        # ! Here we need to swap the grid temporarily but it is
+        # ! important to set up the og grid back for the gradients
+        # temp_interpolation_input.set_temp_grid(grid_0_corners)  # * Prepare grid for next interpolation
+        # output_0_corners: List[InterpOutput] = interpolate_all_fields(  # * This is unnecessary for the last level except for Dual contouring
+        #     interpolation_input=temp_interpolation_input,
+        #     options=options,
+        #     data_descriptor=data_shape
+        # )
+
+        # temp_interpolation_input.set_grid_to_original()
+
+        # * Create next octree level
+        next_octree_level = OctreeLevel(
+            grid_centers=grid_0_centers,
+            grid_corners=grid_0_corners,
+            outputs_centers=output_0_centers,
+            outputs_corners=output_0_corners
+        )
+    else:
+        grid_0_centers: EngineGrid = temp_interpolation_input.grid  # ? This could be moved to the next section
+        output_0_centers: List[InterpOutput] = interpolate_all_fields(temp_interpolation_input, options, data_shape)  # interpolate - centers
+        output_0_corners = []
+        grid_0_corners = None
+
+        # * Create next octree level
+        next_octree_level = OctreeLevel(
+            grid_centers=grid_0_centers,
+            grid_corners=grid_0_corners,
+            outputs_centers=output_0_centers,
+            outputs_corners=output_0_corners
+        )
+
+    return next_octree_level
 
 def _generate_corners_DEP(regular_grid: RegularGrid, level=1) -> np.ndarray:
     if regular_grid is None: raise ValueError("Regular grid is None")

--- a/gempy_engine/API/interp_single/_octree_generation.py
+++ b/gempy_engine/API/interp_single/_octree_generation.py
@@ -71,28 +71,13 @@ def interpolate_on_octree(interpolation_input: InterpolationInput, options: Inte
         grid_0_centers: EngineGrid = temp_interpolation_input.grid  # ? This could be moved to the next section
         xyz_corners = _generate_corners(regular_grid=grid_0_centers.octree_grid)
         
-        if grid_0_centers.custom_grid is None:
-            corner_grid = GenericGrid(values=xyz_corners)
-            grid_0_corners = None
-            output_0_corners = []
-            grid_0_centers.corners_grid = corner_grid
-            output_0_centers: List[InterpOutput] = interpolate_all_fields(temp_interpolation_input, options, data_shape)  # interpolate - centers
-            pass   
-        else:
-            # TODO: Here we would like to append the corners to the custom grid
-            raise NotImplementedError("This should not happen")
-      
-        
-        # ! Here we need to swap the grid temporarily but it is
-        # ! important to set up the og grid back for the gradients
-        # temp_interpolation_input.set_temp_grid(grid_0_corners)  # * Prepare grid for next interpolation
-        # output_0_corners: List[InterpOutput] = interpolate_all_fields(  # * This is unnecessary for the last level except for Dual contouring
-        #     interpolation_input=temp_interpolation_input,
-        #     options=options,
-        #     data_descriptor=data_shape
-        # )
+        corner_grid = GenericGrid(values=xyz_corners)
+        grid_0_centers.corners_grid = corner_grid
+        output_0_centers: List[InterpOutput] = interpolate_all_fields(temp_interpolation_input, options, data_shape)  # interpolate - centers
 
-        # temp_interpolation_input.set_grid_to_original()
+        # * DEP
+        grid_0_corners = None
+        output_0_corners = []
 
         # * Create next octree level
         next_octree_level = OctreeLevel(
@@ -104,6 +89,8 @@ def interpolate_on_octree(interpolation_input: InterpolationInput, options: Inte
     else:
         grid_0_centers: EngineGrid = temp_interpolation_input.grid  # ? This could be moved to the next section
         output_0_centers: List[InterpOutput] = interpolate_all_fields(temp_interpolation_input, options, data_shape)  # interpolate - centers
+
+        # * DEP
         output_0_corners = []
         grid_0_corners = None
 

--- a/gempy_engine/core/data/engine_grid.py
+++ b/gempy_engine/core/data/engine_grid.py
@@ -22,6 +22,7 @@ class EngineGrid:
     topography: Optional[GenericGrid] = None
     sections: Optional[GenericGrid] = None
     geophysics_grid: Optional[CenteredGrid] = None  # TODO: Not implemented this probably will need something different that the generic grid?
+    corners_grid: Optional[GenericGrid] = None  # TODO: Not implemented this probably will need something different that the generic grid?
 
     debug_vals = None
 
@@ -29,13 +30,15 @@ class EngineGrid:
 
     def __init__(self, octree_grid: Optional[RegularGrid] = None, dense_grid: Optional[RegularGrid] = None,
                  custom_grid: Optional[GenericGrid] = None, topography: Optional[GenericGrid] = None,
-                 sections: Optional[GenericGrid] = None, geophysics_grid: Optional[CenteredGrid] = None):
+                 sections: Optional[GenericGrid] = None, geophysics_grid: Optional[CenteredGrid] = None,
+                 cornersGrid: Optional[GenericGrid] = None):
         self.octree_grid = octree_grid
         self.dense_grid = dense_grid
         self.custom_grid = custom_grid
         self.topography = topography
         self.sections = sections
         self.geophysics_grid = geophysics_grid
+        self.corners_grid = cornersGrid
 
     @property
     def regular_grid(self):
@@ -78,6 +81,8 @@ class EngineGrid:
             values.append(self.sections.values)
         if self.geophysics_grid is not None:
             values.append(self.geophysics_grid.values)
+        if self.corners_grid is not None:
+            values.append(self.corners_grid.values)
 
         values_array = BackendTensor.t.concatenate(values, dtype=BackendTensor.dtype)
         values_array = BackendTensor.t.array(values_array, dtype=BackendTensor.dtype)
@@ -129,6 +134,14 @@ class EngineGrid:
         return slice(
             start,
             start + len(self.geophysics_grid) if self.geophysics_grid is not None else start
+        )
+
+    @property
+    def corners_grid_slice(self) -> slice:
+        start = self.geophysics_grid_slice.stop
+        return slice(
+            start,
+            start + len(self.corners_grid) if self.corners_grid is not None else start
         )
 
     @property

--- a/gempy_engine/core/data/engine_grid.py
+++ b/gempy_engine/core/data/engine_grid.py
@@ -31,14 +31,14 @@ class EngineGrid:
     def __init__(self, octree_grid: Optional[RegularGrid] = None, dense_grid: Optional[RegularGrid] = None,
                  custom_grid: Optional[GenericGrid] = None, topography: Optional[GenericGrid] = None,
                  sections: Optional[GenericGrid] = None, geophysics_grid: Optional[CenteredGrid] = None,
-                 cornersGrid: Optional[GenericGrid] = None):
+                 corners_grid: Optional[GenericGrid] = None):
         self.octree_grid = octree_grid
         self.dense_grid = dense_grid
         self.custom_grid = custom_grid
         self.topography = topography
         self.sections = sections
         self.geophysics_grid = geophysics_grid
-        self.corners_grid = cornersGrid
+        self.corners_grid = corners_grid
 
     @property
     def regular_grid(self):

--- a/gempy_engine/core/data/interp_output.py
+++ b/gempy_engine/core/data/interp_output.py
@@ -85,6 +85,14 @@ class InterpOutput:
         return self.block[self.grid.geophysics_grid_slice]
     
     @property
+    def cornersGrid_values(self):
+        return self.block[self.grid.corners_grid_slice]
+
+    @property
+    def ids_cornersGrid(self):
+        return BackendTensor.t.rint(self.block[self.grid.corners_grid_slice])
+
+    @property
     def ids_geophysics_grid(self):
         return BackendTensor.t.rint(self.block[self.grid.geophysics_grid_slice])
 
@@ -129,6 +137,21 @@ class InterpOutput:
         # Get the number of unique lithology IDs
         multiplier = len(BackendTensor.t.unique(litho_ids))
     
+        # Generate the unique IDs
+        unique_ids = litho_ids + faults_ids * multiplier
+        return unique_ids
+
+    @property
+    def litho_faults_ids_corners_grid(self):
+        if self.combined_scalar_field is None:  # * This in principle is only used for testing
+            return self.ids_cornersGrid
+
+        litho_ids = BackendTensor.t.rint(self.block[self.grid.corners_grid_slice])
+        faults_ids = BackendTensor.t.rint(self.faults_block[self.grid.corners_grid_slice])
+
+        # Get the number of unique lithology IDs
+        multiplier = len(BackendTensor.t.unique(litho_ids))
+
         # Generate the unique IDs
         unique_ids = litho_ids + faults_ids * multiplier
         return unique_ids

--- a/gempy_engine/core/data/octree_level.py
+++ b/gempy_engine/core/data/octree_level.py
@@ -48,7 +48,11 @@ class OctreeLevel:
     @property
     def last_output_corners(self):
         return self.outputs_corners[-1]
-    
+
+    @property
+    def litho_faults_ids_corners_grid(self):
+        return self.outputs_centers[-1].litho_faults_ids_corners_grid
+
     @property
     def number_of_outputs(self):
         return len(self.outputs_centers)

--- a/gempy_engine/core/data/regular_grid.py
+++ b/gempy_engine/core/data/regular_grid.py
@@ -20,7 +20,8 @@ class RegularGrid:
     original_values: np.ndarray = field(default=None, repr=False, init=False)  #: When the regular grid is representing a octree level, only active cells are stored in values. This is the original values of the regular grid.
     
     def __len__(self):
-        return self.regular_grid_shape.prod()
+        # return self.regular_grid_shape.prod()
+        return self.values.shape[0]
 
     def __post_init__(self):
         self.regular_grid_shape = _check_and_convert_list_to_array(self.regular_grid_shape)

--- a/gempy_engine/modules/octrees_topology/_octree_internals.py
+++ b/gempy_engine/modules/octrees_topology/_octree_internals.py
@@ -14,7 +14,7 @@ from ...core.data.regular_grid import RegularGrid
 
 def compute_next_octree_locations(prev_octree: OctreeLevel, evaluation_options: EvaluationOptions,
                                   current_octree_level: int) -> EngineGrid:
-    ids = prev_octree.last_output_corners.litho_faults_ids
+    ids = prev_octree.litho_faults_ids_corners_grid
     uv_8 = ids.reshape((-1, 8))
 
     # Old octree

--- a/tests/test_common/test_integrations/test_multi_fields.py
+++ b/tests/test_common/test_integrations/test_multi_fields.py
@@ -147,9 +147,7 @@ def test_plot_corners(unconformity_complex, n_oct_levels=2):
     interpolation_input, options, structure = unconformity_complex
     options.number_octree_levels = n_oct_levels
     solutions: Solutions = compute_model(interpolation_input, options, structure)
-    output_corners: InterpOutput = solutions.octrees_output[-1].outputs_corners[-1]
-
-    vertices = output_corners.grid.values
+    vertices = solutions.octrees_output[-1].grid_centers.corners_grid.values
     if plot_pyvista or False:
         helper_functions_pyvista.plot_pyvista(solutions.octrees_output, v_just_points=vertices)
 

--- a/tests/test_common/test_modules/test_dual.py
+++ b/tests/test_common/test_modules/test_dual.py
@@ -43,10 +43,22 @@ except ImportError:
 
 # pytest ignore
 
-pytestmark = pytest.mark.skip("old _dual_contouring.triangulate_dual_contour has been deprecated. Also"
-                              "output corners have been deprecated and it is intead a subgrid. Updating"
-                              "this tests are a lot of work and for now dual contouring is tested in a"
-                              "higher level test.")
+# pytestmark = pytest.mark.skip("old _dual_contouring.triangulate_dual_contour has been deprecated. Also"
+#                               "output corners have been deprecated and it is intead a subgrid. Updating"
+#                               "this tests are a lot of work and for now dual contouring is tested in a"
+#                               "higher level test.")
+
+
+def _grab_xyz_edges(last_octree_level: OctreeLevel) -> tuple:
+    corners = last_octree_level.outputs_centers[0]
+    # First find xyz on edges:
+    xyz, edges = find_intersection_on_edge(
+        _xyz_corners=last_octree_level.grid_centers.corners_grid.values,
+        scalar_field_on_corners=corners.exported_fields.scalar_field[corners.grid.corners_grid_slice],
+        scalar_at_sp=corners.scalar_field_at_sp,
+        masking=None
+    )
+    return xyz, edges
 
 
 def test_compute_dual_contouring_api(simple_model, simple_grid_3d_octree):
@@ -63,16 +75,18 @@ def test_compute_dual_contouring_api(simple_model, simple_grid_3d_octree):
 
     last_octree_level: OctreeLevel = octree_list[-1]
 
-    corners = last_octree_level.outputs_corners[0]
-    # First find xyz on edges:
-    xyz, edges = find_intersection_on_edge(
-        _xyz_corners=last_octree_level.grid_corners.values,
-        scalar_field_on_corners=corners.exported_fields.scalar_field,
-        scalar_at_sp=corners.scalar_field_at_sp,
-        masking=None
-    )
-    result = xyz, edges
-    intersection_xyz, valid_edges = result
+    # corners = last_octree_level.outputs_corners[0]
+    # # First find xyz on edges:
+    # xyz, edges = find_intersection_on_edge(
+    #     _xyz_corners=last_octree_level.grid_corners.values,
+    #     scalar_field_on_corners=corners.exported_fields.scalar_field,
+    #     scalar_at_sp=corners.scalar_field_at_sp,
+    #     masking=None
+    # )
+    # result = xyz, edges
+    # intersection_xyz, valid_edges = result
+
+    intersection_xyz, valid_edges = _grab_xyz_edges(last_octree_level)
     interpolation_input.set_temp_grid(EngineGrid.from_xyz_coords(intersection_xyz))
 
 

--- a/tests/test_common/test_modules/test_dual.py
+++ b/tests/test_common/test_modules/test_dual.py
@@ -41,6 +41,14 @@ except ImportError:
     plot_pyvista = False
 
 
+# pytest ignore
+
+pytestmark = pytest.mark.skip("old _dual_contouring.triangulate_dual_contour has been deprecated. Also"
+                              "output corners have been deprecated and it is intead a subgrid. Updating"
+                              "this tests are a lot of work and for now dual contouring is tested in a"
+                              "higher level test.")
+
+
 def test_compute_dual_contouring_api(simple_model, simple_grid_3d_octree):
     # region Test find_intersection_on_edge
     spi, ori_i, options, data_shape = simple_model

--- a/tests/test_common/test_modules/test_dual.py
+++ b/tests/test_common/test_modules/test_dual.py
@@ -3,7 +3,6 @@ from typing import List
 
 import pytest
 
-from gempy_engine.API.dual_contouring._interpolate_on_edges import _get_intersection_on_edges
 from gempy_engine.API.interp_single._interp_scalar_field import _evaluate_sys_eq
 from gempy_engine.API.interp_single._interp_single_feature import input_preprocess
 from gempy_engine.API.interp_single._multi_scalar_field_manager import interpolate_all_fields
@@ -56,7 +55,16 @@ def test_compute_dual_contouring_api(simple_model, simple_grid_3d_octree):
 
     last_octree_level: OctreeLevel = octree_list[-1]
 
-    intersection_xyz, valid_edges = _get_intersection_on_edges(last_octree_level, last_octree_level.outputs_corners[0])
+    corners = last_octree_level.outputs_corners[0]
+    # First find xyz on edges:
+    xyz, edges = find_intersection_on_edge(
+        _xyz_corners=last_octree_level.grid_corners.values,
+        scalar_field_on_corners=corners.exported_fields.scalar_field,
+        scalar_at_sp=corners.scalar_field_at_sp,
+        masking=None
+    )
+    result = xyz, edges
+    intersection_xyz, valid_edges = result
     interpolation_input.set_temp_grid(EngineGrid.from_xyz_coords(intersection_xyz))
 
 
@@ -124,10 +132,16 @@ def test_compute_mesh_extraction_fancy_triangulation(simple_model, simple_grid_3
 
     octree_level_for_surface: OctreeLevel = octree_list[options.number_octree_levels_surface - 1]
 
-    intersection_xyz, valid_edges = _get_intersection_on_edges(
-        octree_level=octree_level_for_surface,
-        output_corners=octree_level_for_surface.outputs_corners[0]
+    corners = octree_level_for_surface.outputs_corners[0]
+    # First find xyz on edges:
+    xyz, edges = find_intersection_on_edge(
+        _xyz_corners=octree_level_for_surface.grid_corners.values,
+        scalar_field_on_corners=corners.exported_fields.scalar_field,
+        scalar_at_sp=corners.scalar_field_at_sp,
+        masking=None
     )
+    result = xyz, edges
+    intersection_xyz, valid_edges = result
 
     interpolation_input.set_temp_grid(EngineGrid.from_xyz_coords(intersection_xyz))
     output_on_edges: List[InterpOutput] = interpolate_all_fields(interpolation_input, options, data_shape)
@@ -245,7 +259,16 @@ def test_compute_dual_contouring_several_meshes(simple_model_3_layers, simple_gr
 
     last_octree_level: OctreeLevel = octree_list[-1]
 
-    intersection_xyz, valid_edges = _get_intersection_on_edges(last_octree_level, last_octree_level.outputs_corners[0])
+    corners = last_octree_level.outputs_corners[0]
+    # First find xyz on edges:
+    xyz, edges = find_intersection_on_edge(
+        _xyz_corners=last_octree_level.grid_corners.values,
+        scalar_field_on_corners=corners.exported_fields.scalar_field,
+        scalar_at_sp=corners.scalar_field_at_sp,
+        masking=None
+    )
+    result = xyz, edges
+    intersection_xyz, valid_edges = result
     interpolation_input.set_temp_grid(EngineGrid.from_xyz_coords(intersection_xyz))
 
     output_on_edges = interp.interpolate_single_field(interpolation_input, options, data_shape.tensors_structure)

--- a/tests/test_common/test_modules/test_octrees.py
+++ b/tests/test_common/test_modules/test_octrees.py
@@ -4,13 +4,9 @@ import os
 import pytest
 
 import gempy_engine.API.interp_single.interp_features as interp
-from gempy_engine.API.interp_single._octree_generation import _generate_corners
-from gempy_engine.core.data.engine_grid import EngineGrid
 from gempy_engine.core.data.interpolation_input import InterpolationInput
-from gempy_engine.core.data.octree_level import OctreeLevel
 from gempy_engine.modules.octrees_topology.octrees_topology_interface import get_next_octree_grid, \
     get_regular_grid_value_for_level
-from .test_dual import _compute_actual_mesh
 from ...conftest import plot_pyvista, TEST_SPEED
 
 dir_name = os.path.dirname(__file__)


### PR DESCRIPTION
# Combining centers and corners

This PR refactors the dual contouring implementation to use a more efficient approach for handling grid corners:

- Adds `corners_grid` property to `EngineGrid` to store corner values alongside centers
- Modifies `interpolate_on_octree` to compute corners as part of the center grid rather than separately
- Adds corner-related properties to `InterpOutput` for accessing corner data
- Fixes `__len__` in `RegularGrid` to return the correct number of active cells
- Replaces `_get_intersection_on_edges` with direct calls to `find_intersection_on_edge` for improved consistency
- Updates masking logic to work with the new grid structure
- Simplifies octree generation by removing redundant corner-related code

These changes improve the efficiency of the dual contouring algorithm by reducing redundant computations and simplifying the data flow.