### PR TITLE
[FIX] Correct vertex index calculation in meshes_to_subsurface method | GEN-13490

### DIFF
--- a/gempy_engine/core/data/raw_arrays_solution.py
+++ b/gempy_engine/core/data/raw_arrays_solution.py
@@ -119,11 +119,11 @@ class RawArraysSolution:
 
         vertex: list[np.ndarray] = self.vertices
         simplex_list: list[np.ndarray] = self.edges
-
+        
         idx_max = 0
-        for simplex_array in simplex_list:
+        for i, simplex_array in enumerate(simplex_list):
             simplex_array += idx_max
-            idx_max = simplex_array.max() + 1
+            idx_max += vertex[i].shape[0]  # Add the number of vertices in this mesh
 
         vertex_id_array = [np.full(v.shape[0], i + 1) for i, v in enumerate(vertex)]
         cell_id_array = [np.full(v.shape[0], i + 1) for i, v in enumerate(simplex_list)]


### PR DESCRIPTION
### TL;DR

Fixed a bug in the mesh indexing logic when converting meshes to subsurface format.

### What changed?

Modified the `meshes_to_subsurface` method to correctly calculate the index offset when combining multiple meshes. Instead of using the maximum value in the current simplex array, the code now adds the number of vertices in each mesh to properly increment the index counter.

### How to test?

Test the `meshes_to_subsurface` method with multiple meshes of different sizes to verify that the vertex indices are correctly offset and that no index overlapping occurs between different meshes.

### Why make this change?

The previous implementation incorrectly calculated the index offset by using the maximum value in the current simplex array. This could lead to index overlapping or gaps when combining meshes with non-sequential vertex indices. The new approach ensures that indices are properly incremented based on the actual number of vertices in each mesh, resulting in correctly connected mesh structures.