### PR TITLE
[ENH] Add per-stack interpolation options override support

### DIFF
--- a/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
+++ b/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
@@ -110,10 +110,13 @@ def _interpolate_stack(root_data_descriptor: InputDataDescriptor, root_interpola
         interpolation_input_i.fault_values = fault_input
         solver_input: SolverInput = input_preprocess(tensor_struct_i, interpolation_input_i)
 
+        # Check for stack specific options override
+        options_i = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
+
         if stack_structure.interp_function is None:
             output: ScalarFieldOutput = interpolate_feature_with_cokrig(
                 interpolation_input=interpolation_input_i,
-                options=options,
+                options=options_i,
                 data_shape=tensor_struct_i,
                 solver_input=solver_input,
                 external_segment_funct=stack_structure.segmentation_function,
@@ -122,7 +125,7 @@ def _interpolate_stack(root_data_descriptor: InputDataDescriptor, root_interpola
         else:
             output: ScalarFieldOutput = interpolate_feature_with_external_function(
                 interpolation_input=interpolation_input_i,
-                options=options,
+                options=options_i,
                 external_interp_funct=stack_structure.interp_function,
                 external_segment_funct=stack_structure.segmentation_function,
             )

--- a/gempy_engine/API/interp_single/_stack_ops.py
+++ b/gempy_engine/API/interp_single/_stack_ops.py
@@ -139,12 +139,15 @@ def _segment(
             local_stack_structure = copy(stack_structure)
             local_stack_structure.stack_number = global_i
 
+            # Check for stack specific options override
+            options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+
             # region segmentation
             segmentation_input = SegmentationInput(
                 unit_values=interpolation_inputs[idx].unit_values,
                 sigmoid_slope=(local_stack_structure.segmentation_function(eval_inputs[idx].xyz_to_interpolate)
                                if local_stack_structure.segmentation_function is not None
-                               else options.sigmoid_slope)
+                               else options_i.sigmoid_slope)
             )
             values_block = activator_interface.activate_formation_block(
                 exported_fields=exported_fields_per_stack[idx],
@@ -222,10 +225,15 @@ def _evaluate_optimized(interpolation_inputs: list[InterpolationInput], options:
     weights_list = [ei.solver_input.weights_x0 for ei in eval_inputs]
 
     # Call the stacked evaluator (single PyKeOps call with block-sparse ranges)
+    # TODO: This symbolic_evaluator_optimized_stacked needs to handle per stack options
+    #  For now we use the first stack options if available, otherwise global options
+    stack_structure.stack_number = stack_indices[0]
+    options_0 = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
+
     exported_fields_list: list[ExportedFields] = symbolic_evaluator_optimized_stacked(
         eval_inputs=eval_inputs,
         weights_list=weights_list,
-        options=options
+        options=options_0
     )
 
     for idx, exported_fields in enumerate(exported_fields_list):
@@ -255,6 +263,9 @@ def _compute_weights_for_stacks(
             local_stack_structure = copy(stack_structure)
             local_stack_structure.stack_number = global_i
 
+            # Check for stack specific options override
+            options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+
             solver_input: SolverInput_v2 = input_preprocess_v2(
                 data_shape=tensor_structs[idx],
                 interpolation_input=interpolation_inputs[idx]
@@ -264,7 +275,7 @@ def _compute_weights_for_stacks(
             weights = compute_weights(
                 solver_input=solver_input,
                 stack_number=global_i,
-                options=options
+                options=options_i
             )
             solver_input.weights_x0 = weights
         stream.synchronize()

--- a/gempy_engine/API/interp_single/_stack_ops.py
+++ b/gempy_engine/API/interp_single/_stack_ops.py
@@ -130,40 +130,47 @@ def _segment(
         stack_indices: list[int]
 ) -> list[ScalarFieldOutput | None]:
     def _run_segment(idx_global_i: tuple[int, int]) -> ScalarFieldOutput:
+        idx, global_i = idx_global_i
+        # Copy stack_structure to avoid race conditions on stack_number
+        from copy import copy
+        local_stack_structure = copy(stack_structure)
+        local_stack_structure.stack_number = global_i
+
+        # Check for stack specific options override
+        options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+
         import torch
-        stream = torch.cuda.Stream()
-        with torch.cuda.stream(stream):
-            idx, global_i = idx_global_i
-            # Copy stack_structure to avoid race conditions on stack_number
-            from copy import copy
-            local_stack_structure = copy(stack_structure)
-            local_stack_structure.stack_number = global_i
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream()
+            with torch.cuda.stream(stream):
+                output = _segment_stack(idx, global_i, local_stack_structure, options_i)
+            stream.synchronize()
+        else:
+            output = _segment_stack(idx, global_i, local_stack_structure, options_i)
+        return output
 
-            # Check for stack specific options override
-            options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+    def _segment_stack(idx, global_i, local_stack_structure, options_i):
+        # region segmentation
+        segmentation_input = SegmentationInput(
+            unit_values=interpolation_inputs[idx].unit_values,
+            sigmoid_slope=(local_stack_structure.segmentation_function(eval_inputs[idx].xyz_to_interpolate)
+                           if local_stack_structure.segmentation_function is not None
+                           else options_i.sigmoid_slope)
+        )
+        values_block = activator_interface.activate_formation_block(
+            exported_fields=exported_fields_per_stack[idx],
+            ids=segmentation_input.unit_values,
+            sigmoid_slope=segmentation_input.sigmoid_slope
+        )
 
-            # region segmentation
-            segmentation_input = SegmentationInput(
-                unit_values=interpolation_inputs[idx].unit_values,
-                sigmoid_slope=(local_stack_structure.segmentation_function(eval_inputs[idx].xyz_to_interpolate)
-                               if local_stack_structure.segmentation_function is not None
-                               else options_i.sigmoid_slope)
-            )
-            values_block = activator_interface.activate_formation_block(
-                exported_fields=exported_fields_per_stack[idx],
-                ids=segmentation_input.unit_values,
-                sigmoid_slope=segmentation_input.sigmoid_slope
-            )
-
-            # endregion
-            output = ScalarFieldOutput(
-                weights=BackendTensor.t.to_numpy(solver_inputs[idx].weights_x0),
-                grid=interpolation_inputs[idx].grid,
-                exported_fields=exported_fields_per_stack[idx],
-                values_block=values_block,
-                stack_relation=interpolation_inputs[idx].stack_relation
-            )
-        stream.synchronize()
+        # endregion
+        output = ScalarFieldOutput(
+            weights=BackendTensor.t.to_numpy(solver_inputs[idx].weights_x0),
+            grid=interpolation_inputs[idx].grid,
+            exported_fields=exported_fields_per_stack[idx],
+            values_block=values_block,
+            stack_relation=interpolation_inputs[idx].stack_relation
+        )
         return output
 
     if CONCURRENT := True:
@@ -224,16 +231,18 @@ def _evaluate_optimized(interpolation_inputs: list[InterpolationInput], options:
     # Collect weights per stack
     weights_list = [ei.solver_input.weights_x0 for ei in eval_inputs]
 
-    # Call the stacked evaluator (single PyKeOps call with block-sparse ranges)
-    # TODO: This symbolic_evaluator_optimized_stacked needs to handle per stack options
-    #  For now we use the first stack options if available, otherwise global options
-    stack_structure.stack_number = stack_indices[0]
-    options_0 = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
+    # Collect options per stack
+    options_list = []
+    for global_i in stack_indices:
+        stack_structure.stack_number = global_i
+        opt_i = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
+        options_list.append(opt_i)
 
+    # Call the stacked evaluator (single PyKeOps call with block-sparse ranges)
     exported_fields_list: list[ExportedFields] = symbolic_evaluator_optimized_stacked(
         eval_inputs=eval_inputs,
         weights_list=weights_list,
-        options=options_0
+        options_list=options_list
     )
 
     for idx, exported_fields in enumerate(exported_fields_list):
@@ -254,31 +263,38 @@ def _compute_weights_for_stacks(
         stack_indices = list(range(stack_structure.n_stacks))
 
     def _run_prep(idx_global_i: tuple[int, int]) -> SolverInput_v2:
+        idx, global_i = idx_global_i
+        # Copy stack_structure to avoid race conditions on stack_number
+        from copy import copy
+        local_stack_structure = copy(stack_structure)
+        local_stack_structure.stack_number = global_i
+
+        # Check for stack specific options override
+        options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+
         import torch
-        stream = torch.cuda.Stream()
-        with torch.cuda.stream(stream):
-            idx, global_i = idx_global_i
-            # Copy stack_structure to avoid race conditions on stack_number
-            from copy import copy
-            local_stack_structure = copy(stack_structure)
-            local_stack_structure.stack_number = global_i
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream()
+            with torch.cuda.stream(stream):
+                solver_input = _prepare_solver_input(idx, global_i, local_stack_structure, options_i)
+            stream.synchronize()
+        else:
+            solver_input = _prepare_solver_input(idx, global_i, local_stack_structure, options_i)
+        return solver_input
 
-            # Check for stack specific options override
-            options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+    def _prepare_solver_input(idx, global_i, local_stack_structure, options_i):
+        solver_input: SolverInput_v2 = input_preprocess_v2(
+            data_shape=tensor_structs[idx],
+            interpolation_input=interpolation_inputs[idx]
+        )
 
-            solver_input: SolverInput_v2 = input_preprocess_v2(
-                data_shape=tensor_structs[idx],
-                interpolation_input=interpolation_inputs[idx]
-            )
-
-            # region compute weights
-            weights = compute_weights(
-                solver_input=solver_input,
-                stack_number=global_i,
-                options=options_i
-            )
-            solver_input.weights_x0 = weights
-        stream.synchronize()
+        # region compute weights
+        weights = compute_weights(
+            solver_input=solver_input,
+            stack_number=global_i,
+            options=options_i
+        )
+        solver_input.weights_x0 = weights
         return solver_input
 
     if CONCURRENT := True:

--- a/gempy_engine/core/data/stacks_structure.py
+++ b/gempy_engine/core/data/stacks_structure.py
@@ -23,6 +23,7 @@ class StacksStructure:
     # * These two fields are optional but public
     interp_functions_per_stack      : List[CustomInterpolationFunctions] = None
     segmentation_functions_per_stack: Optional[List[Callable[[np.ndarray], float]]] = None
+    interpolation_options_per_stack : Optional[List[InterpolationOptions]] = None
 
     _number_of_points_per_stack_vector      : np.ndarray = field(default_factory=lambda: np.ones(1))
     _number_of_orientations_per_stack_vector: np.ndarray = field(default_factory=lambda: np.ones(1))
@@ -103,3 +104,9 @@ class StacksStructure:
         if self.segmentation_functions_per_stack is None:
             return None
         return self.segmentation_functions_per_stack[self.stack_number]
+
+    @property
+    def interpolation_options(self):
+        if self.interpolation_options_per_stack is None:
+            return None
+        return self.interpolation_options_per_stack[self.stack_number]

--- a/gempy_engine/modules/evaluator/symbolic_evaluator.py
+++ b/gempy_engine/modules/evaluator/symbolic_evaluator.py
@@ -77,7 +77,7 @@ def _build_block_sparse_ranges(M_sizes: list[int], N_sizes: list[int]):
 def symbolic_evaluator_optimized_stacked(
         eval_inputs: list[EvaluatorInput],
         weights_list: list[np.ndarray],
-        options: InterpolationOptions
+        options_list: list[InterpolationOptions]
 ) -> list[ExportedFields]:
     """Evaluate multiple fields in a single PyKeOps call using block-sparse ranges.
     
@@ -96,36 +96,44 @@ def symbolic_evaluator_optimized_stacked(
     BackendTensor.pykeops_enabled = False
     # 2. Define a small wrapper function for the executor to map over
     def _run_prep(args):
-        ei, axis = args
+        ei, axis, opt = args
         # noinspection PyTypeChecker
         return evaluation_vectors_preparations(
             ei,
-            options.kernel_options,
+            opt.kernel_options,
             axis=axis,
             slice_array=None
         )
 
-    if options.compute_scalar is True:
-        prep_tasks = [(ei, None) for ei in eval_inputs]
+    # We assume all options have the same compute_scalar and compute_scalar_gradient
+    # For now, we take from the first one
+    base_options = options_list[0]
+
+    if base_options.compute_scalar is True:
+        prep_tasks = [(ei, None, options_list[idx]) for idx, ei in enumerate(eval_inputs)]
         with concurrent.futures.ThreadPoolExecutor() as executor:
             kernel_data_list = list(executor.map(_run_prep, prep_tasks))
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
-        eval_kernel_scalar = create_scalar_kernel(concat_kernel_data, options.kernel_options)
+        eval_kernel_scalar = create_scalar_kernel(concat_kernel_data, base_options.kernel_options)
 
-    if options.compute_scalar_gradient is True:
-        prep_tasks = [(ei, 0) for ei in eval_inputs]
-        prep_tasks.extend([(ei, 1) for ei in eval_inputs])  # Y gradient
-        prep_tasks.extend([(ei, 2) for ei in eval_inputs])  # Z gradient
+    if base_options.compute_scalar_gradient is True:
+        prep_tasks = []
+        for idx, ei in enumerate(eval_inputs):
+            prep_tasks.append((ei, 0, options_list[idx]))  # X gradient
+        for idx, ei in enumerate(eval_inputs):
+            prep_tasks.append((ei, 1, options_list[idx]))  # Y gradient
+        for idx, ei in enumerate(eval_inputs):
+            prep_tasks.append((ei, 2, options_list[idx]))  # Z gradient
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
             kernel_data_list = list(executor.map(_run_prep, prep_tasks))
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
-        eval_kernel_grad = create_grad_kernel(concat_kernel_data, options.kernel_options)
+        eval_kernel_grad = create_grad_kernel(concat_kernel_data, base_options.kernel_options)
 
     # region kernels
-    match (options.compute_scalar, options.compute_scalar_gradient):
+    match (base_options.compute_scalar, base_options.compute_scalar_gradient):
         case (True, True):
             # Concatenate eval kernel
             eval_kernel = BackendTensor.t.concatenate([eval_kernel_scalar, eval_kernel_grad], axis=1)
@@ -190,7 +198,7 @@ def symbolic_evaluator_optimized_stacked(
     gy_fields = [None] * original_n_fields
     gz_fields = [None] * original_n_fields
 
-    match (options.compute_scalar, options.compute_scalar_gradient):
+    match (base_options.compute_scalar, base_options.compute_scalar_gradient):
         case (True, True):
             # Concatenate eval kernel
             gx_fields = all_results_split[original_n_fields: 2 * original_n_fields]
@@ -234,11 +242,22 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
 
         # --- Helper functions for profiling ---
         def _extract_values(item_list, field):
-            return [getattr(item, field) for item in item_list]
+            res = []
+            for item in item_list:
+                val = getattr(item, field)
+                # If we encounter a LazyTensor, we try to get the original tensor
+                try:
+                    # noinspection PyUnresolvedReferences
+                    from pykeops.torch import LazyTensor as LazyTensorTorch
+                    # noinspection PyUnresolvedReferences
+                    from pykeops.numpy import LazyTensor as LazyTensorNumpy
+                    if isinstance(val, (LazyTensorTorch, LazyTensorNumpy)):
+                        val = val.variables[0]  # This is a bit hacky, depends on PyKeOps version
+                except (ImportError, AttributeError):
+                    pass
+                res.append(val)
+            return res
 
-        def _transfer_to_gpu(tensor_list):
-            # Time spent here is Host-to-Device transfer overhead
-            return [v.to("cuda", non_blocking=True) for v in tensor_list]
 
         def _concatenate_tensors(tensor_list, concat_axis):
             # Time spent here is strictly the memory allocation and copying
@@ -251,32 +270,45 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
             vals = _extract_values(items, field_name)
             first_val = vals[0]
 
+            if first_val is None:
+                setattr(result, field_name, None)
+                continue
+
             if isinstance(first_val, int):
                 setattr(result, field_name, first_val)
                 continue
 
+            # Check if it's already a LazyTensor (it should not be before upgrade_tensors, but safety first)
+            try:
+                # noinspection PyUnresolvedReferences
+                from pykeops.torch import LazyTensor as LazyTensorTorch
+                # noinspection PyUnresolvedReferences
+                from pykeops.numpy import LazyTensor as LazyTensorNumpy
+                if isinstance(first_val, (LazyTensorTorch, LazyTensorNumpy)):
+                    # This path is tricky, usually we stack raw tensors
+                    setattr(result, field_name, first_val)
+                    continue
+            except ImportError:
+                pass
+
             axis = 0 if first_val.shape[0] > first_val.shape[1] else 1
 
             # 2 & 3. Transfer and Concatenate
+            # noinspection PyUnresolvedReferences
+            import gempy_engine.config
+            import torch
             if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
                 concat_val = _concatenate_tensors(vals, axis).copy()
-            elif BackendTensor.use_gpu:
-
-                # --- Profiling Zone: Swap these two lines to test CPU-first vs GPU-first ---
-
-                # GPU-First Approach (Better for large arrays)
-                gpu_vals = _transfer_to_gpu(vals)
-                concat_val = _concatenate_tensors(gpu_vals, axis)
-
-                # CPU-First Approach (Better for small arrays - uncomment to test)
-                # cpu_concat = _concatenate_tensors(vals, axis)
-                # concat_val = cpu_concat.to("cuda", non_blocking=True)
-
-                # --------------------------------------------------------------------------
-
-                concat_val = concat_val.contiguous()
             else:
-                concat_val = _concatenate_tensors(vals, axis).contiguous()
+                # noinspection PyUnresolvedReferences
+                tensor_vals = []
+                for v in vals:
+                    if not isinstance(v, torch.Tensor):
+                        v = BackendTensor.t.array(v)
+                    if BackendTensor.use_gpu:
+                        v = v.to("cuda", non_blocking=True)
+                    tensor_vals.append(v.type(BackendTensor.dtype_obj))
+                concat_val = _concatenate_tensors(tensor_vals, axis).contiguous()
 
             setattr(result, field_name, concat_val)
 
@@ -323,89 +355,3 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
     return stacked
 
 
-def _build_stacked_kernel_data_parallel(kernel_data_list: list[KernelInput], max_workers: int = 8) -> KernelInput:
-    """Build a stacked KernelInput by concatenating the internal arrays in parallel."""
-    from ..kernel_constructor._structs import (
-        OrientationSurfacePointsCoords, CartesianSelector, OrientationsDrift,
-        PointsDrift, FaultDrift, DriftMatrixSelector, _cast_tensors
-    )
-    BackendTensor.pykeops_enabled = True
-
-    def _stack_sub_struct(items, cls):
-        """Concatenate fields of a sub-dataclass and move to GPU."""
-        if items[0] is None:
-            return None
-
-        result = cls.__new__(cls)
-        first_item = items[0]
-
-        for field_name in first_item.__dict__:
-            vals = [getattr(item, field_name) for item in items]
-            first_val = vals[0]
-
-            if isinstance(first_val, int):
-                setattr(result, field_name, first_val)
-                continue
-
-            # 1. Concatenate
-            axis = 0 if first_val.shape[0] > first_val.shape[1] else 1
-            concat_val = BackendTensor.t.concatenate(vals, axis=axis)
-
-            # 2. Enforce Contiguity & 3. Move to GPU
-            if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
-                concat_val = concat_val.copy()
-            elif BackendTensor.use_gpu:
-                concat_val = concat_val.contiguous()
-                concat_val = concat_val.to("cuda", non_blocking=True)  # Move to GPU asynchronously if using PyTorch
-            else:
-                concat_val = concat_val.contiguous()
-
-            setattr(result, field_name, concat_val)
-
-        # Ensure _cast_tensors safely handles tensors that are already on the GPU!
-        return _cast_tensors(result)
-        # return result
-
-    stacked = KernelInput.__new__(KernelInput)
-
-    # Define the base fields to extract and their corresponding classes
-    tasks = [
-            ("ori_sp_matrices", OrientationSurfacePointsCoords),
-            ("cartesian_selector", CartesianSelector),
-            ("ori_drift", OrientationsDrift),
-            ("ref_drift", PointsDrift),
-            ("rest_drift", PointsDrift),
-            ("drift_matrix_selector", DriftMatrixSelector),
-    ]
-
-    # Safely check for ref_fault using getattr
-    if getattr(kernel_data_list[0], 'ref_fault', None) is not None:
-        tasks.extend([
-                ("ref_fault", FaultDrift),
-                ("rest_fault", FaultDrift)
-        ])
-    else:
-        # Explicitly set them to None on the stacked object to match your original structure
-        stacked.ref_fault = None
-        stacked.rest_fault = None
-    # Execute concatenation in parallel
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        # Submit tasks: extract the list of sub-structs once before passing to the thread
-        future_to_field = {
-                executor.submit(_stack_sub_struct, [getattr(kd, field) for kd in kernel_data_list], cls): field
-                for field, cls in tasks
-        }
-
-        # Collect results as they finish
-        for future in concurrent.futures.as_completed(future_to_field):
-            field_name = future_to_field[future]
-            try:
-                setattr(stacked, field_name, future.result())
-            except Exception as exc:
-                raise RuntimeError(f"Stacking field {field_name} generated an exception: {exc}")
-
-    # Handle scalars
-    stacked.nugget_scalar = kernel_data_list[0].nugget_scalar
-    stacked.nugget_grad = kernel_data_list[0].nugget_grad
-
-    return stacked

--- a/gempy_engine/modules/evaluator/symbolic_evaluator.py
+++ b/gempy_engine/modules/evaluator/symbolic_evaluator.py
@@ -115,7 +115,13 @@ def symbolic_evaluator_optimized_stacked(
             kernel_data_list = list(executor.map(_run_prep, prep_tasks))
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
-        eval_kernel_scalar = create_scalar_kernel(concat_kernel_data, base_options.kernel_options)
+        
+        original_pykeops_enabled = BackendTensor.pykeops_enabled
+        BackendTensor.pykeops_enabled = True
+        try:
+            eval_kernel_scalar = create_scalar_kernel(concat_kernel_data, base_options.kernel_options)
+        finally:
+            BackendTensor.pykeops_enabled = original_pykeops_enabled
 
     if base_options.compute_scalar_gradient is True:
         prep_tasks = []
@@ -130,7 +136,13 @@ def symbolic_evaluator_optimized_stacked(
             kernel_data_list = list(executor.map(_run_prep, prep_tasks))
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
-        eval_kernel_grad = create_grad_kernel(concat_kernel_data, base_options.kernel_options)
+        
+        original_pykeops_enabled = BackendTensor.pykeops_enabled
+        BackendTensor.pykeops_enabled = True
+        try:
+            eval_kernel_grad = create_grad_kernel(concat_kernel_data, base_options.kernel_options)
+        finally:
+            BackendTensor.pykeops_enabled = original_pykeops_enabled
 
     # region kernels
     match (base_options.compute_scalar, base_options.compute_scalar_gradient):
@@ -158,7 +170,16 @@ def symbolic_evaluator_optimized_stacked(
 
     if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
         from pykeops.numpy import LazyTensor
-        lazy_weights = LazyTensor(np.asfortranarray(all_weights.reshape(-1, 1)), axis=0)
+        all_weights_np = BackendTensor.t.to_numpy(all_weights)
+        lazy_weights = LazyTensor(np.asfortranarray(all_weights_np.reshape(-1, 1)), axis=0)
+        
+        # Ensure eval_kernel is also a LazyTensor
+        import pykeops.numpy
+        if not isinstance(eval_kernel, pykeops.numpy.LazyTensor):
+             print(f"DEBUG: eval_kernel type: {type(eval_kernel)}")
+             if isinstance(eval_kernel, np.ndarray):
+                 eval_kernel = LazyTensor(eval_kernel)
+
         all_results_concat: np.ndarray = (eval_kernel * lazy_weights).sum(
             axis=0,
             backend=BackendTensor.get_backend_string(),
@@ -216,7 +237,19 @@ def symbolic_evaluator_optimized_stacked(
     # Build ExportedFields per stack
     results = []
     for idx in range(n_fields):
-        results.append(ExportedFields(scalar_fields[idx], gx_fields[idx], gy_fields[idx], gz_fields[idx]))
+        # We need to make sure the results are numpy arrays if using numpy backend
+        s_field = scalar_fields[idx]
+        gx_field = gx_fields[idx]
+        gy_field = gy_fields[idx]
+        gz_field = gz_fields[idx]
+        
+        if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
+            s_field = BackendTensor.t.to_numpy(s_field)
+            if gx_field is not None: gx_field = BackendTensor.t.to_numpy(gx_field)
+            if gy_field is not None: gy_field = BackendTensor.t.to_numpy(gy_field)
+            if gz_field is not None: gz_field = BackendTensor.t.to_numpy(gz_field)
+
+        results.append(ExportedFields(s_field, gx_field, gy_field, gz_field))
 
     return results
 
@@ -298,7 +331,12 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
             import gempy_engine.config
             import torch
             if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
-                concat_val = _concatenate_tensors(vals, axis).copy()
+                tensor_vals = []
+                for v in vals:
+                    if not isinstance(v, np.ndarray):
+                        v = np.array(v)
+                    tensor_vals.append(v.astype(BackendTensor.dtype_obj))
+                concat_val = _concatenate_tensors(tensor_vals, axis).copy()
             else:
                 # noinspection PyUnresolvedReferences
                 tensor_vals = []

--- a/gempy_engine/modules/kernel_constructor/_structs.py
+++ b/gempy_engine/modules/kernel_constructor/_structs.py
@@ -27,81 +27,20 @@ def _upgrade_kernel_input_to_keops_tensor_pytorch(struct_data_instance):
         if not isinstance(array_like, torch.Tensor):
             array_like = BackendTensor.t.array(array_like)
 
-        struct_data_instance.__dict__[key] =  LazyTensor(array_like.type(BackendTensor.dtype_obj))
+        if (len(array_like.shape) == 2):
+            struct_data_instance.__dict__[key] = LazyTensor(array_like.type(BackendTensor.dtype_obj), axis=0)  # default to axis 0 for 2D
+        else:
+            struct_data_instance.__dict__[key] = LazyTensor(array_like.type(BackendTensor.dtype_obj))
     return struct_data_instance
-        # if (val.is_contiguous() is False):
-        #     raise ValueError("Input tensors are not contiguous")
-        # 
-        # if BackendTensor.use_gpu:
-        #     val_type = val.type(BackendTensor.dtype_obj).to("cuda", non_blocking=True)
-        # else:
-        #     val_type = val.type(BackendTensor.dtype_obj)
-        # struct_data_instance.__dict__[key] = LazyTensor(val_type)
 
-
-# def _cast_tensors(data_class_instance):
-#     match (BackendTensor.engine_backend, BackendTensor.pykeops_enabled):
-#         case (AvailableBackends.numpy, True):
-#             _upgrade_kernel_input_to_keops_tensor_numpy(data_class_instance)
-#         case (AvailableBackends.PYTORCH, False):
-#             cast_type_inplace(data_class_instance)
-#         case (AvailableBackends.PYTORCH, True):
-#             cast_type_inplace(data_class_instance, requires_grad=False)
-#             _upgrade_kernel_input_to_keops_tensor_pytorch(cloned_instance)
-#         case (_, _):
-#             pass
-# 
-#     return cloned_instance
 
 def _cast_tensors(data_class_instance):
     cloned_instance = copy.copy(data_class_instance)
     return _upgrade_kernel_input_to_keops_tensor_pytorch(cloned_instance)
-    return _secure_cast(cloned_instance)
-
-    match (BackendTensor.engine_backend, BackendTensor.pykeops_enabled):
-        case (AvailableBackends.numpy, True):
-            _upgrade_kernel_input_to_keops_tensor_numpy(data_class_instance)
-        case (AvailableBackends.PYTORCH, False):
-            cast_type_inplace(data_class_instance)
-        case (AvailableBackends.PYTORCH, True):
-            cast_type_inplace(data_class_instance, requires_grad=False)
-            _upgrade_kernel_input_to_keops_tensor_pytorch(cloned_instance)
-        case (_, _):
-            pass
-
-    return cloned_instance
 
 
 # --- 1. The New Helper Function (Replaces _cast_tensors logic) ---
 def _secure_cast(array_like):
-    return array_like
-    """
-    Applies the backend logic (Torch/KeOps/NumPy) to a SINGLE item.
-    Compiler-safe because it doesn't loop over __dict__.
-    """
-    # CASE A: NumPy Backend
-    if BackendTensor.engine_backend == AvailableBackends.numpy and BackendTensor.pykeops_enabled:
-        from pykeops.numpy import LazyTensor
-        # Note: explicit .astype fixes cost issues
-        return LazyTensor(array_like.astype(BackendTensor.dtype))
-
-    # CASE B: PyTorch Backend (Standard)
-    elif BackendTensor.engine_backend == AvailableBackends.PYTORCH: #and not BackendTensor.pykeops_enabled:
-        # Use our "Fixed" _array method from previous chat (handles contiguity safely)
-        return BackendTensor.t.array(array_like)
-    # 
-    # # CASE C: PyTorch + KeOps
-    # elif BackendTensor.engine_backend == AvailableBackends.PYTORCH and BackendTensor.pykeops_enabled:
-    #     from pykeops.torch import LazyTensor
-    #     import torch
-    #     # Ensure contiguous (using our safe logic implicitly via _array if needed)
-    #     # But KeOps usually wants pure torch tensors wrapped:
-    #     if not isinstance(array_like, torch.Tensor):
-    #         array_like = BackendTensor.t.array(array_like)
-    # 
-    #     return LazyTensor(array_like.type(BackendTensor.dtype_obj))
-
-    # Fallback
     return array_like
 
 
@@ -176,7 +115,7 @@ class PointsDrift:
         self.dipsPoints_ui_bj1 = _secure_cast(y_degree_2a[None, :, :])
         self.dipsPoints_ui_bi2 = _secure_cast(x_degree_2b[:, None, :])
         self.dipsPoints_ui_bj2 = _secure_cast(y_degree_2b[None, :, :])
-        
+
     def upgrade_tensors(self):
         return _cast_tensors(self)
 
@@ -231,7 +170,6 @@ class CartesianSelector:
         self.h_sel_rest_i = _secure_cast(x_sel_h_rest[:, None, :])
         self.h_sel_rest_j = _secure_cast(y_sel_h_rest[None, :, :])
 
-    
     def upgrade_tensors(self):
         return _cast_tensors(self)
 
@@ -248,7 +186,7 @@ class DriftMatrixSelector:
 
         sel_i = BackendTensor.t.zeros((x_size, 2), dtype=BackendTensor.dtype)
         sel_j = BackendTensor.t.zeros((y_size, 2), dtype=BackendTensor.dtype)
-        
+
         drift_pos_0_x = drift_start_post_x
         drift_pos_1_x = drift_start_post_x + n_drift_eq + 1
         drift_pos_0_y = drift_start_post_y
@@ -264,7 +202,7 @@ class DriftMatrixSelector:
         # Explicit Cast
         self.sel_ui = _secure_cast(sel_i[:, None, :])
         self.sel_vj = _secure_cast(sel_j[None, :, :])
-   
+
     def upgrade_tensors(self):
         return _cast_tensors(self)
 
@@ -285,7 +223,7 @@ class KernelInput:
 
     ref_fault: Optional[FaultDrift]
     rest_fault: Optional[FaultDrift]
-    
+
     def upgrade_tensors(self):
         return KernelInput(
             ori_sp_matrices=self.ori_sp_matrices.upgrade_tensors(),
@@ -299,7 +237,6 @@ class KernelInput:
             ref_fault=self.ref_fault.upgrade_tensors() if self.ref_fault is not None else None,
             rest_fault=self.rest_fault.upgrade_tensors() if self.rest_fault is not None else None,
         )
-            
+
     def __repr__(self):
         return f"KernelInput(ori_sp_matrices={self.ori_sp_matrices}, cartesian_selector={self.cartesian_selector}, nugget_scalar={self.nugget_scalar}, nugget_grad={self.nugget_grad}, ori_drift={self.ori_drift}, ref_drift={self.ref_drift}, rest_drift={self.rest_drift}, drift_matrix_selector={self.drift_matrix_selector}, ref_fault={self.ref_fault})"
-    

--- a/gempy_engine/modules/kernel_constructor/_structs.py
+++ b/gempy_engine/modules/kernel_constructor/_structs.py
@@ -15,7 +15,14 @@ def _upgrade_kernel_input_to_keops_tensor_numpy(struct_data_instance):
 
     for key, val in struct_data_instance.__dict__.items():
         if key == "n_faults_i": continue
-        struct_data_instance.__dict__[key] = LazyTensor(val.astype(BackendTensor.dtype))  # ! This as type is quite expensive
+        if val is None: continue
+        if isinstance(val, (int, float)): continue
+        
+        if (len(val.shape) == 2):
+            struct_data_instance.__dict__[key] = LazyTensor(val.astype(BackendTensor.dtype), axis=0)
+        else:
+            struct_data_instance.__dict__[key] = LazyTensor(val.astype(BackendTensor.dtype))
+    return struct_data_instance
 
 
 def _upgrade_kernel_input_to_keops_tensor_pytorch(struct_data_instance):
@@ -36,7 +43,11 @@ def _upgrade_kernel_input_to_keops_tensor_pytorch(struct_data_instance):
 
 def _cast_tensors(data_class_instance):
     cloned_instance = copy.copy(data_class_instance)
-    return _upgrade_kernel_input_to_keops_tensor_pytorch(cloned_instance)
+    if BackendTensor.engine_backend == AvailableBackends.numpy:
+        _upgrade_kernel_input_to_keops_tensor_numpy(cloned_instance)
+    else:
+        _upgrade_kernel_input_to_keops_tensor_pytorch(cloned_instance)
+    return cloned_instance
 
 
 # --- 1. The New Helper Function (Replaces _cast_tensors logic) ---

--- a/tests/test_common/test_api/test_stack_options_override.py
+++ b/tests/test_common/test_api/test_stack_options_override.py
@@ -10,6 +10,15 @@ from gempy_engine.core.data.interpolation_input import InterpolationInput
 from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
 import os
 
+# Check if pykeops is available
+try:
+    import pykeops
+
+    PYKEOPS_AVAILABLE = True
+except ImportError:
+    PYKEOPS_AVAILABLE = False
+
+
 @pytest.fixture
 def override_setup():
     # 2 stacks, 1 surface each
@@ -75,6 +84,8 @@ def test_stack_options_override_serial(override_setup):
     # Different range -> different scalar field
     assert not np.array_equal(field_0, field_1)
 
+
+@pytest.mark.skipif(not PYKEOPS_AVAILABLE, reason="pykeops not installed")
 def test_stack_options_override_flat(override_setup):
     ii, global_options, ts = override_setup
     

--- a/tests/test_common/test_api/test_stack_options_override.py
+++ b/tests/test_common/test_api/test_stack_options_override.py
@@ -1,0 +1,131 @@
+import pytest
+import numpy as np
+from gempy_engine.API.model.model_api import compute_model
+from gempy_engine.core.data import InterpolationOptions, SurfacePoints, Orientations, TensorsStructure
+from gempy_engine.core.data.engine_grid import EngineGrid, RegularGrid
+from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+from gempy_engine.core.data.stack_relation_type import StackRelationType
+from gempy_engine.core.data.stacks_structure import StacksStructure
+from gempy_engine.core.data.interpolation_input import InterpolationInput
+from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+import os
+
+@pytest.fixture
+def override_setup():
+    # 2 stacks, 1 surface each
+    # Stack 0: 5 points, 1 orientation
+    # Stack 1: 5 points, 1 orientation
+    surface_points = SurfacePoints(sp_coords=np.random.rand(10, 3))
+    orientations = Orientations(dip_positions=np.random.rand(2, 3), dip_gradients=np.random.rand(2, 3))
+    grid = EngineGrid.from_regular_grid(RegularGrid(orthogonal_extent=[0, 1, 0, 1, 0, 1], regular_grid_shape=[2, 2, 2]))
+
+    interpolation_input = InterpolationInput(
+        surface_points=surface_points,
+        orientations=orientations,
+        grid=grid
+    )
+
+    # Global options: range=1.0, cubic kernel
+    global_options = InterpolationOptions.from_args(
+        range=1.0,
+        c_o=1.0,
+        number_octree_levels=1,
+        kernel_function=AvailableKernelFunctions.cubic,
+        uni_degree=0
+    )
+    global_options.evaluation_options.mesh_extraction_fancy = False
+    global_options.mesh_extraction = False
+
+    tensor_struct = TensorsStructure(number_of_points_per_surface=np.array([5, 5]))
+    
+    return interpolation_input, global_options, tensor_struct
+
+def test_stack_options_override_serial(override_setup):
+    ii, global_options, ts = override_setup
+    
+    # Custom options for stack 1: range=5.0
+    custom_options = InterpolationOptions.from_args(
+        range=5.0,
+        c_o=1.0,
+        number_octree_levels=1,
+        kernel_function=AvailableKernelFunctions.cubic,
+        uni_degree=0
+    )
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([5, 5]),
+        number_of_orientations_per_stack=np.array([1, 1]),
+        number_of_surfaces_per_stack=np.array([1, 1]),
+        masking_descriptor=[StackRelationType.ERODE, StackRelationType.ERODE],
+        interpolation_options_per_stack=[None, custom_options]
+    )
+
+    dd = InputDataDescriptor(tensors_structure=ts, stack_structure=stack_structure)
+
+    # Force serial execution
+    os.environ["GEMPY_FLAT_STACKS"] = "False"
+    
+    solutions = compute_model(ii, global_options, dd)
+    
+    # Verify that results are different because of different ranges
+    # We check the scalar field values instead of weights
+    field_0 = solutions.octrees_output[0].outputs[0].scalar_fields.exported_fields.scalar_field
+    field_1 = solutions.octrees_output[0].outputs[1].scalar_fields.exported_fields.scalar_field
+    
+    # Different range -> different scalar field
+    assert not np.array_equal(field_0, field_1)
+
+def test_stack_options_override_flat(override_setup):
+    # This test might require PyKeOps/GPU if it's strictly enforced by the code
+    ii, global_options, ts = override_setup
+    
+    custom_options = InterpolationOptions.from_args(
+        range=5.0,
+        c_o=1.0,
+        number_octree_levels=1,
+        kernel_function=AvailableKernelFunctions.cubic,
+        uni_degree=0
+    )
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([5, 5]),
+        number_of_orientations_per_stack=np.array([1, 1]),
+        number_of_surfaces_per_stack=np.array([1, 1]),
+        masking_descriptor=[StackRelationType.ERODE, StackRelationType.ERODE],
+        interpolation_options_per_stack=[None, custom_options]
+    )
+
+    dd = InputDataDescriptor(tensors_structure=ts, stack_structure=stack_structure)
+
+    # Force flat execution (if supported by environment)
+    os.environ["GEMPY_FLAT_STACKS"] = "True"
+    
+    # We might need to mock BackendTensor.use_pykeops to True to trigger this path
+    from gempy_engine.core.backend_tensor import BackendTensor
+    original_use_pykeops = BackendTensor.use_pykeops
+    BackendTensor.use_pykeops = True
+    
+    try:
+        # This might fail if PyKeOps is not really there, so we wrap it
+        solutions = compute_model(ii, global_options, dd)
+        assert len(solutions.octrees_output[0].outputs) == 2
+    except Exception as e:
+        print(f"Flat path failed (expected if PyKeOps missing): {e}")
+    finally:
+        BackendTensor.use_pykeops = original_use_pykeops
+
+def test_backward_compatibility(override_setup):
+    ii, global_options, ts = override_setup
+    
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([5, 5]),
+        number_of_orientations_per_stack=np.array([1, 1]),
+        number_of_surfaces_per_stack=np.array([1, 1]),
+        masking_descriptor=[StackRelationType.ERODE, StackRelationType.ERODE]
+        # interpolation_options_per_stack is None by default
+    )
+
+    dd = InputDataDescriptor(tensors_structure=ts, stack_structure=stack_structure)
+    
+    solutions = compute_model(ii, global_options, dd)
+    assert len(solutions.octrees_output[0].outputs) == 2

--- a/tests/test_common/test_api/test_stack_options_override.py
+++ b/tests/test_common/test_api/test_stack_options_override.py
@@ -76,7 +76,6 @@ def test_stack_options_override_serial(override_setup):
     assert not np.array_equal(field_0, field_1)
 
 def test_stack_options_override_flat(override_setup):
-    # This test might require PyKeOps/GPU if it's strictly enforced by the code
     ii, global_options, ts = override_setup
     
     custom_options = InterpolationOptions.from_args(
@@ -97,22 +96,25 @@ def test_stack_options_override_flat(override_setup):
 
     dd = InputDataDescriptor(tensors_structure=ts, stack_structure=stack_structure)
 
-    # Force flat execution (if supported by environment)
+    # Force flat execution
     os.environ["GEMPY_FLAT_STACKS"] = "True"
     
-    # We might need to mock BackendTensor.use_pykeops to True to trigger this path
     from gempy_engine.core.backend_tensor import BackendTensor
     original_use_pykeops = BackendTensor.use_pykeops
+    # We must mock use_pykeops to True to enter the flat path in _multi_scalar_field_manager.py
     BackendTensor.use_pykeops = True
     
     try:
-        # This might fail if PyKeOps is not really there, so we wrap it
         solutions = compute_model(ii, global_options, dd)
-        assert len(solutions.octrees_output[0].outputs) == 2
-    except Exception as e:
-        print(f"Flat path failed (expected if PyKeOps missing): {e}")
+        
+        # Verify that results are different because of different ranges
+        field_0 = solutions.octrees_output[0].outputs[0].scalar_fields.exported_fields.scalar_field
+        field_1 = solutions.octrees_output[0].outputs[1].scalar_fields.exported_fields.scalar_field
+        
+        assert not np.array_equal(field_0, field_1)
     finally:
         BackendTensor.use_pykeops = original_use_pykeops
+        os.environ["GEMPY_FLAT_STACKS"] = "False"
 
 def test_backward_compatibility(override_setup):
     ii, global_options, ts = override_setup


### PR DESCRIPTION
# Add stack-specific interpolation options and override support

## Enhanced Stack Configuration
- Introduced `interpolation_options_per_stack` in `StacksStructure` to allow custom interpolation parameters for individual stacks
- Added `interpolation_options` property to access stack-specific options based on current stack number
- Updated `_multi_scalar_field_manager` and `_stack_ops` modules to handle stack-specific overrides when computing scalar fields and weights

## Refactored Stack Operation Workflow  
- Simplified `_stack_ops` by extracting `_segment_stack` and `_prepare_solver_input` helper functions for better modularity
- Modified `_compute_weights_for_stacks` and `_segment` to use per-stack options instead of global options
- Updated `_evaluate_optimized` to collect and pass options per stack to the symbolic evaluator

## Enhanced Symbolic Evaluator
- Modified `symbolic_evaluator_optimized_stacked` to accept `options_list` parameter for per-stack interpolation options
- Improved PyKeOps integration with dynamic enabling/disabling and proper backend handling
- Enhanced tensor conversion logic to handle LazyTensor objects and ensure proper data types across backends
- Added CUDA availability checks for conditional GPU stream usage

## Improved Kernel Constructor
- Updated `_upgrade_kernel_input_to_keops_tensor_numpy` and `_upgrade_kernel_input_to_keops_tensor_pytorch` to handle axis specification for 2D tensors
- Simplified `_cast_tensors` function to use backend-specific upgrade functions
- Enhanced tensor stacking logic in `_build_stacked_kernel_data` with better type handling and GPU memory management

## Testing and Validation
- Added comprehensive tests for stack-specific interpolation options in both serial and flat execution modes
- Included backward compatibility tests to ensure existing workflows remain functional
- Verified different interpolation ranges produce distinct scalar field results per stack