### PR TITLE
[ENH] Improve tensor conversion handling and integrate `BackendTensor.t` for GPU compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,239 @@
+# GemPy Engine — Agent Guide
+
+## Project Overview
+
+GemPy Engine is a Python library for implicit 3D geological modeling using cokriging interpolation. It generates scalar fields from surface point and orientation data, refines them over an octree, and optionally extracts surfaces via dual contouring.
+
+**Key dependencies**: NumPy, PyTorch (optional), PyKeOps (optional), FastAPI (server), subsurface (output export).
+
+## Build / Test / Run
+
+### Workspace Environment
+
+The virtual environment for this project is located at `/home/leguark/.venv/2025`. To avoid package collision or import errors, always run commands using the virtualenv's direct executables rather than global ones.
+
+### Essential Commands
+
+```bash
+# Install in dev mode
+/home/leguark/.venv/2025/bin/pip install -e ".[dev]"
+
+# Run tests with the default/numpy backend
+DEFAULT_BACKEND=numpy /home/leguark/.venv/2025/bin/pytest
+
+# Run tests and skip approval tests
+DEFAULT_BACKEND=numpy /home/leguark/.venv/2025/bin/pytest -k "not approval"
+
+# Run a specific test file
+DEFAULT_BACKEND=numpy /home/leguark/.venv/2025/bin/pytest tests/test_common/test_api/test_public_interface.py
+
+# Run the FastAPI server
+/home/leguark/.venv/2025/bin/uvicorn gempy_engine.API.server.main_server_pro:gempy_engine_App
+```
+
+*Note*: If you run a generic `pytest` command, you may hit `ImportPathMismatchError` due to leftovers in build directories (e.g., `build/lib/tests/conftest.py` vs `tests/conftest.py`). If this occurs, clean up the build artifacts first via `rm -rf build/`.
+
+---
+
+## Architecture
+
+```
+API/              ← Public entry points
+  model/model_api.py    → compute_model() — the one main entry point
+  interp_single/        → Octree-level interpolation loop + stack management
+  dual_contouring/      → Multi-scalar dual contouring mesh extraction
+  server/               → FastAPI endpoint wrapping compute_model()
+
+core/             ← Data structures, backend abstraction, utilities
+  backend_tensor.py     → BackendTensor singleton (NumPy vs PyTorch, CPU/GPU, PyKeOps)
+  data/                 → All domain data classes (grids, inputs, options, outputs)
+  config.py             → Environment-based configuration (AvailableBackends, feature flags)
+  exceptions.py         → GemPyEngineInputError
+
+modules/          ← Computational modules (no direct outside deps)
+  kernel_constructor/   → Builds covariance matrices and kernel evaluation
+  solver/               → Linear system solvers (NumPy, PyTorch, PyKeOps CG, GMRES)
+  activator/            → Soft-sigmoid segmentation of scalar fields into unit blocks
+  dual_contouring/      → Mesh generation from scalar field on octree corners
+  evaluator/            → Evaluates weights against kernel to produce scalar fields
+  octrees_topology/     → Octree refinement based on scalar field curvature
+  data_preprocess/      → Prepares raw input for interpolation
+  faults/               → Finite fault handling
+  geophysics/           → Forward gravity and magnetic computation
+  weights_cache/        → Disk/memory cache for interpolation weights
+  topology/             → Topology edge extraction from octree
+```
+
+---
+
+## Control Flow
+
+```
+compute_model(InterpolationInput, InterpolationOptions, InputDataDescriptor)
+  │
+  ├─ _check_input_validity()            ← Pre-computation validity check
+  │
+  ├─ interpolate_n_octree_levels()
+  │    └─ for each octree level:
+  │         └─ interpolate_on_octree()
+  │              └─ interpolate_all_fields()
+  │                   └─ _interpolate_stack()  (or _interpolate_stack_flat)
+  │                        └─ for each stack (geological series):
+  │                             ├─ input_preprocess() → SolverInput
+  │                             ├─ compute_weights()  → solve Ax=b → weights
+  │                             │    └─ solver_interface.kernel_reduction()
+  │                             ├─ _evaluate_sys_eq()  → evaluate kernel → ExportedFields
+  │                             └─ _segment()  → sigmoid activation → values block
+  │                   └─ combine_scalar_fields()  → erosion/onlap masking
+  │              └─ get_next_octree_grid()  → refine octree for next level
+  │
+  ├─ dual_contouring_multi_scalar()  (if mesh_extraction=True)
+  │
+  └─ Solutions(octrees_output, dc_meshes, gravity, magnetics)
+```
+
+---
+
+## Key Concepts & Data Structures
+
+### BackendTensor — The Compute Backend
+`BackendTensor` is a **class with mutable class-level state** (not instantiated). It controls:
+- **Engine backend**: `AvailableBackends.numpy` or `AvailableBackends.PYTORCH`.
+- **GPU**: `use_gpu` flag (PyTorch only).
+- **PyKeOps**: `pykeops_enabled` / `use_pykeops` for GPU-accelerated kernel ops.
+
+The class provides aliases for backend operations: `BackendTensor.t` (the active backend module, e.g. NumPy or PyTorch), `BackendTensor.tfnp` (same, primarily for numpy-like syntax). All computation-agnostic code uses `BackendTensor.t.array(...)`, `BackendTensor.t.zeros(...)`, etc.
+
+**Critical**: `pykeops_enabled` is **dynamically toggled** at runtime by `compute_weights()` and `_evaluate_sys_eq()` in `_interp_scalar_field.py` — they set and restore it per-call. Do not rely on the class-level value staying constant during a `compute_model()` run.
+
+**Test backend** is configured via `tests/conftest.py`:
+```python
+BackendTensor._change_backend(engine_backend=backend, use_gpu=use_gpu)
+```
+Default test backend is `AvailableBackends.numpy`, GPU off.
+
+### Stacks and Surfaces
+The modeling is organized into **stacks** (geological series/sequences) each containing multiple **surfaces** (geological boundaries).
+
+- `StacksStructure`: Describes the organization — number of surfaces, points, orientations **per stack**, masking relations (erosion, onlap, fault), and fault dependency matrix.
+- `TensorsStructure`: Describes number of surface points per surface (lower-level split).
+- `InputDataDescriptor`: Pairs `TensorsStructure` + `StacksStructure`. Frozen dataclass.
+
+**Stacks are interpolated independently**, then combined via masking:
+- **Erosion**: Upper stack's scalar field truncates lower stacks.
+- **Onlap**: Lower stack's scalar field truncates upper stacks.
+- **Fault**: Output modifies the combined block with fault offsets.
+
+### Input Validation
+Before interpolation starts, the `compute_model` entry point runs a comprehensive check `_check_input_validity(...)`. It raises a `GemPyEngineInputError` if it detects inconsistencies:
+- Mismatches in orientation dip positions vs gradients lengths.
+- Inconsistencies between `InterpolationInput` size and expectations set in `TensorsStructure` or `StacksStructure` (e.g. point/surface counts).
+- Stacks or surfaces containing zero points or zero orientations.
+
+### Options Classes & Deprecation Patterns
+- `InterpolationOptions`: Pydantic `BaseModel` (with `ConfigDict`). Holds `kernel_options`, `evaluation_options`, `cache_mode`, `sigmoid_slope`, etc.
+- `KernelOptions`: Standard `@dataclass` (not Pydantic). Holds `range`, `c_o`, `uni_degree`, `kernel_function`, `kernel_solver`, `compute_condition_number`.
+- `EvaluationOptions`: `@dataclass`. Holds octree level counts, mesh extraction flags, gradient computation.
+
+**Implicit Deprecation Gotcha**:
+Several high-level attributes on `InterpolationOptions` are deprecated (such as `compute_scalar_gradient`, `number_octree_levels`, `number_octree_levels_surface`, and `mesh_extraction`). When modifying or creating configuration, access/set these on `options.evaluation_options` instead (e.g., `options.evaluation_options.number_octree_levels`).
+
+### Grid System
+`EngineGrid` is a composite that holds multiple grid types: `octree_grid`, `dense_grid`, `custom_grid`, `topography`, `sections`, `geophysics_grid`, `corners_grid`. Its `.values` property concatenates all non-None grids in a fixed order. Slices (`octree_grid_slice`, `dense_grid_slice`, etc.) partition the concatenated array to extract per-grid sub-arrays from final blocks.
+
+### Octree Levels
+The engine iterates over `number_octree_levels` levels. At each level:
+1. Evaluate scalar field at current grid points
+2. If not the last level, compute next octree grid from scalar field curvature
+3. Set the new octree grid on `interpolation_input` via `set_temp_grid()`
+
+The final octree output level's `InterpOutput.combined_scalar_field.final_block` is the geological model result.
+
+### The Deep Copy Requirement
+For NumPy backend (not PyTorch), `compute_model()` does `copy.deepcopy(interpolation_input)` to avoid side effects. Controlled by `NOT_MAKE_INPUT_DEEP_COPY` env var. The deep copy is **not** done for PyTorch backend — be aware of this when debugging PyTorch vs NumPy behavior differences.
+
+---
+
+## Environment Configuration
+
+Configuration lives in `gempy_engine/config.py`, loaded from `.env` or `~/.env_gempy_engine`. The local `.env` is prioritized if both exist.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DEBUG_MODE` | `False` | Extra assertions and debug output |
+| `DEFAULT_BACKEND` | `numpy` | `numpy` or `PYTORCH` |
+| `DEFAULT_PYKEOPS` | `False` | Enable PyKeOps GPU kernels |
+| `DEFAULT_TENSOR_DTYPE` | `float64` | Tensor data type |
+| `OPTIMIZE_MEMORY` | `True` | Memory optimization flag |
+| `SET_RAW_ARRAYS_IN_SOLUTION` | `True` | Populate `Solutions.raw_arrays` |
+| `NOT_MAKE_INPUT_DEEP_COPY` | `False` | Skip input deep copy |
+| `GEMPY_FLAT_STACKS` | `False` | Use parallel chunk-based stack processing |
+| `GEMPY_MAX_CHUNK_SIZE` | `32000000000` | Max "cost" per chunk for flat stacks |
+| `ONLY_LITH_SOLUTION` | `False` | Skip non-lithology blocks in output |
+| `PYKEOPS_SOLVER` | `False` | Use PyKeOps for solver (not just kernel) |
+
+---
+
+## Coding Conventions
+
+- **Bold separator comments**: `# region ... # endregion` used for logical code grouping.
+- **Switch comments**: `# @off` / `# @on` to disable/enable code sections (e.g. around specific math blocks).
+- **TODO tags**: `# TODO`, `# ?`, `# *` prefixed comments for notes/questions.
+- **Underbar prefix**: Private module-internal functions use `_` prefix (e.g., `_solve_interpolation`).
+- **Type annotations**: Heavy use of type hints throughout, but some are approximate (e.g., `Union` on `BackendTensor.tensor_types`).
+- **Backend-agnostic code** uses `BackendTensor.t` for array ops; direct NumPy/PyTorch calls must be avoided in core computational paths.
+
+---
+
+## Testing
+
+Tests are organized in `tests/`:
+- `test_core/` — Data structure tests.
+- `test_modules/` — Per-module tests (activator, dual contouring, kernel constructor, solvers, geophysics, etc.).
+- `test_common/test_api/` — Integration tests using the public `compute_model()` API.
+- `test_integrations/` — Multi-field, multi-grid, options integration.
+- `test_server/` — Server endpoint tests.
+- `test_pytorch/` — PyTorch backend gradient tests.
+- `fixtures/` — Reusable pytest fixtures for models, grids, geometries.
+- `test_dependencies/` — Checks for optional deps (PyKeOps compiler).
+
+Test speed/requirement levels are set in `tests/conftest.py`:
+```python
+TEST_SPEED = TestSpeed.MINUTES
+REQUIREMENT_LEVEL = Requirements.CORE
+```
+
+Approval tests (via `pytest-approvaltests`) store expected output in `.approved.txt` files. They use a PyCharm diff reporter configured in conftest.
+
+---
+
+## Common Pitfalls & Troubleshooting
+
+1. **`BackendTensor` state leaks**: The singleton's class-level state persists across test runs. If a test changes the backend, subsequent tests may run with the wrong backend. Test conftest sets it at import time, but individual tests can still mutate it.
+
+2. **`pykeops_enabled` vs `use_pykeops`**: `pykeops_enabled` is the runtime toggle, `use_pykeops` is the user-configured preference. The runtime code sets `pykeops_enabled = use_pykeops` at key points and may temporarily disable it.
+
+3. **Deep copy in compute_model**: The deep copy can mask mutation bugs. If a test modifies `InterpolationInput` after calling `compute_model()`, it may or may not affect the result depending on the backend.
+
+4. **Unit values default**: `InterpolationInput.unit_values` returns `np.arange(1000)` if never set — a non-obvious fallback.
+
+5. **`KernelOptions` is a dataclass, `InterpolationOptions` is Pydantic**: They use different patterns for validation, serialization, and defaults.
+
+6. **Grid slices must stay in sync**: The `EngineGrid.values` concatenation order must match the slice properties. Adding a new grid type requires adding it to both.
+
+7. **`StacksStructure.stack_number` mutation**: The `stack_number` field is mutated during the stack loop — it's used as a cursor for active stack lookup via properties like `active_masking_descriptor`.
+
+8. **`Solutions._raw_arrays` is only populated if `SET_RAW_ARRAYS_IN_SOLUTION=True` AND the first octree level has an octree grid**. Dense grid models skip raw arrays.
+
+9. **Server mode uses hardcoded default options** in `main_server_pro.py:29-36` — changing `InterpolationOptions` defaults won't affect server behavior.
+
+10. **The `compute_model` exception handler** catches and re-raises, but the `finally` block always clears the weight cache and GPU memory. If `compute_model` is called in a loop, each call starts with a clean cache.
+
+11. **PyKeOps Permission Errors**:
+    When running tests, some PyKeOps test scripts attempt to write cache files to hardcoded paths such as `/home/miguel` (e.g. in `tests/test_dependencies/test_pykeops.py`). This leads to a `PermissionError: [Errno 13] Permission denied`. This test can be ignored or skipped in environments where `/home/miguel` is inaccessible.
+
+12. **PyKeOps LazyTensor Operations**:
+    PyKeOps lazy evaluation has strict constraints on tensor inputs. Performing standard numpy functions or PyTorch ufuncs (like `sqrt`) on a raw `LazyTensor` can raise `TypeError: operand 'LazyTensor' does not support ufuncs` or `ValueError` due to axis expectations. Operations involving PyKeOps must strictly follow the wrapper functions or explicit lazy math structures.
+
+13. **Global Pytest Path Mismatches**:
+    When calling `pytest` without path restrictions, Python may attempt to collect from the `build/` directory if a previous compilation was performed. This causes an `ImportPathMismatchError` on `tests/conftest.py`. Always target tests explicitly or clear `build/` before running tests.

--- a/TEAMCITY_FIX_SUMMARY.md
+++ b/TEAMCITY_FIX_SUMMARY.md
@@ -1,0 +1,37 @@
+# TeamCity PyTorch Fix — Strategy
+
+## What
+
+Make the PyTorch backend (`Gempy_TestingEnginePyTorch`) fully green on TeamCity.
+It currently has 5 failures — all backend-agnostic code that assumes NumPy types and breaks
+when `BackendTensor` is set to `PYTORCH`.
+
+## How TeamCity is used
+
+1. **`teamcity job list`** → find the right job (`Gempy_TestingEnginePyTorch`)
+2. **`teamcity run start <job> --personal --branch @this --local-changes --watch`** →
+   upload local changes as a **personal build** (doesn't pollute the main pipeline),
+   waits for completion.
+3. **`teamcity run tests <id> --failed`** / **`teamcity run log <id> --raw`** →
+   extract failure details from the build log.
+4. Iterate: fix locally → push to same branch → re-trigger personal build.
+
+Command used:
+```bash
+teamcity run start Gempy_TestingEnginePyTorch \
+  --personal --branch @this --local-changes --watch --timeout 30m \
+  -m "Fix PyTorch tensor reduction"
+```
+
+## Failures being fixed
+
+| # | Test | Error | Fix |
+|---|------|-------|-----|
+| 1 | `test_final_block_octrees` | `Tensor.astype()` doesn't exist | guard with `hasattr(..., 'cpu')` → `.cpu().numpy()` |
+| 2-4 | `test_activator_*` (×3) | `repeat_interleave(numpy, Tensor, dim=…)` wrong types | convert args to Tensor in `BackendTensor._repeat` |
+| 5 | `test_final_exported_fields_one_layer` | `reshape` 4050 → (15,2,15) shape mismatch | investigating |
+
+## Files changed
+
+- `gempy_engine/core/backend_tensor.py` — `_repeat` now auto-converts numpy→Tensor
+- `tests/test_common/test_integrations/test_multi_fields.py` — Tensor-safe `.astype` call

--- a/gempy_engine/API/interp_single/_interp_scalar_field.py
+++ b/gempy_engine/API/interp_single/_interp_scalar_field.py
@@ -48,7 +48,7 @@ def compute_weights(solver_input: Union[SolverInput, SolverInput_v2], stack_numb
         case _:
             raise ValueError("Cache mode not recognized")
 
-    if os.getenv("PYKEOPS_SOLVER, False") == "True":
+    if os.getenv("PYKEOPS_SOLVER", "False") == "True":
         BackendTensor.pykeops_enabled = True
     else:
         BackendTensor.pykeops_enabled = False

--- a/gempy_engine/core/backend_tensor.py
+++ b/gempy_engine/core/backend_tensor.py
@@ -463,7 +463,7 @@ class BackendTensor:
             torch.cuda.synchronize()
 
         # 2. GC: Safely destroy orphaned Python/C++ objects
-        gc.collect()
+        # gc.collect() ! This takes a very long time, I have to balance the reliability vs performance
 
         if BackendTensor.use_gpu:
             # 3. Release VRAM: Give the memory back to the OS

--- a/gempy_engine/core/backend_tensor.py
+++ b/gempy_engine/core/backend_tensor.py
@@ -192,6 +192,10 @@ class BackendTensor:
             return _true_torch_sum(tensor, axis, dtype=dtype)
 
         def _repeat(tensor, n_repeats, axis=None):
+            if not isinstance(tensor, torch.Tensor):
+                tensor = torch.as_tensor(tensor, device=cls.device)
+            if not isinstance(n_repeats, torch.Tensor):
+                n_repeats = torch.as_tensor(n_repeats, device=cls.device)
             return _true_torch_repeat_interleave(tensor, n_repeats, dim=axis)
 
         def _array(array_like, dtype=None):
@@ -248,7 +252,7 @@ class BackendTensor:
 
         def _to_numpy(tensor):
             """Convert tensor to numpy array, handling GPU tensors properly"""
-            if hasattr(tensor, 'device') and tensor.device.type == 'cuda':
+            if isinstance(tensor, torch.Tensor) and tensor.device.type == 'cuda':
                 # Move to CPU first, then detach and convert to numpy
                 return tensor.cpu().detach().numpy()
             elif hasattr(tensor, 'detach'):
@@ -372,7 +376,7 @@ class BackendTensor:
 
     @classmethod
     def _wrap_pykeops_functions(cls):
-        torch_available = cls.engine_backend == AvailableBackends.PYTORCH
+        torch_available = is_pytorch_installed
 
         def _exp(tensor):
             match tensor:

--- a/gempy_engine/plugins/plotting/helper_functions.py
+++ b/gempy_engine/plugins/plotting/helper_functions.py
@@ -12,12 +12,17 @@ from gempy_engine.core.data.output.blocks_value_type import ValueType
 
 
 def plot_2d_scalar_y_direction(interpolation_input: InterpolationInput, Z_x, grid: RegularGrid = None):
+    from gempy_engine.core.backend_tensor import BackendTensor
     if grid is None:
         resolution = interpolation_input.grid.octree_grid.resolution
         extent = interpolation_input.grid.octree_grid.orthogonal_extent
     else:
         resolution = grid.resolution
         extent = grid.orthogonal_extent
+
+    resolution = tuple(BackendTensor.t.to_numpy(resolution).astype(int))
+    extent = BackendTensor.t.to_numpy(extent)
+    Z_x = BackendTensor.t.to_numpy(Z_x)
 
     plt.contourf(
         Z_x.reshape(resolution)[:, resolution[1] // 2, :].T,
@@ -57,8 +62,10 @@ def calculate_gradient(dip, az, pol):
 
 
 def plot_block(block, grid: RegularGrid, interpolation_input=None, direction="y"):
-    resolution = tuple(grid.resolution)
-    extent = grid.orthogonal_extent
+    from gempy_engine.core.backend_tensor import BackendTensor
+    resolution = tuple(BackendTensor.t.to_numpy(grid.resolution).astype(int))
+    extent = BackendTensor.t.to_numpy(grid.orthogonal_extent)
+    block = BackendTensor.t.to_numpy(block)
     if direction == "y":
         plt.imshow(block.reshape(resolution)[:, resolution[1] // 2, :].T, extent=extent[[0, 1, 4, 5]], origin="lower")
     if direction == "x":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,17 @@ class Requirements(enum.Enum):
     DEV = 2
 
 
-TEST_SPEED = TestSpeed.MINUTES  # * Use seconds for compile errors, minutes before pushing and hours before release
-REQUIREMENT_LEVEL = Requirements.CORE  # * Use CORE for mandatory tests, OPTIONAL for optional tests and DEV for development tests
+# * Allow CI to override via env vars; fall back to defaults if value is invalid
+_test_speed_name = os.getenv('TEST_SPEED', 'MINUTES')
+_requirement_name = os.getenv('REQUIREMENT_LEVEL', 'CORE')
+try:
+    TEST_SPEED = TestSpeed[_test_speed_name]
+except KeyError:
+    TEST_SPEED = TestSpeed.MINUTES
+try:
+    REQUIREMENT_LEVEL = Requirements[_requirement_name]
+except KeyError:
+    REQUIREMENT_LEVEL = Requirements.CORE
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,12 @@ def set_up_approval_tests():
 def tests_root():
     # Return the root 'tests/' directory
     return os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(autouse=True)
+def restore_backend():
+    current_backend = BackendTensor.engine_backend
+    current_use_gpu = BackendTensor.use_gpu
+    yield
+    if BackendTensor.engine_backend != current_backend or BackendTensor.use_gpu != current_use_gpu:
+        BackendTensor._change_backend(engine_backend=current_backend, use_gpu=current_use_gpu)

--- a/tests/test_common/test_integrations/test_multi_fields.py
+++ b/tests/test_common/test_integrations/test_multi_fields.py
@@ -161,7 +161,10 @@ def test_final_block_octrees(unconformity_complex, n_oct_levels=2):
     )
 
     final_block = solution.octrees_output[0].last_output_center.final_block
-    final_block2 = get_regular_grid_value_for_level(solution.octrees_output, 1).astype("int8")
+    final_block2 = get_regular_grid_value_for_level(solution.octrees_output, 1)
+    if hasattr(final_block2, 'cpu'):
+        final_block2 = final_block2.cpu().numpy()
+    final_block2 = final_block2.astype("int8")
 
     if plot_2d := False or False:
         grid = interpolation_input.grid.regular_grid

--- a/tests/test_common/test_modules/test_exporter.py
+++ b/tests/test_common/test_modules/test_exporter.py
@@ -188,6 +188,6 @@ def test_final_exported_fields_one_layer(unconformity_complex_one_layer):
         grid = interpolation_input.grid.octree_grid
         from gempy_engine.core.backend_tensor import BackendTensor
         plot_block(
-            BackendTensor.t.to_numpy(outputs[0].final_exported_fields._scalar_field),
+            BackendTensor.t.to_numpy(outputs[0].final_exported_fields.scalar_field),
             grid
         )

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_faults.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_faults.py
@@ -40,7 +40,8 @@ def test_transforming_implicit_ellipsoid():
     extent = np.array([-500, 500., -500, 500, -450, 550]) / rescaling_factor
     regular_grid = RegularGrid(extent, resolution)
 
-    xyz = regular_grid.values
+    from gempy_engine.core.backend_tensor import BackendTensor
+    xyz = BackendTensor.t.to_numpy(regular_grid.values)
     center = np.array([0, 0, 0])
     radius = np.array([1, 1, 2]) * 1
     f = 1

--- a/tests/test_common/test_modules/test_octrees.py
+++ b/tests/test_common/test_modules/test_octrees.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 import pytest
 
+from gempy_engine.core.backend_tensor import BackendTensor
 import gempy_engine.API.interp_single.interp_features as interp
 from gempy_engine.core.data.interpolation_input import InterpolationInput
 from gempy_engine.modules.octrees_topology.octrees_topology_interface import get_next_octree_grid, \
@@ -39,7 +40,7 @@ def test_octree_leaf(simple_model, simple_grid_3d_octree):
 
     # Assert
 
-    regular_grid_scalar = get_regular_grid_value_for_level(octree_list).astype("int8")
+    regular_grid_scalar = BackendTensor.t.to_numpy(get_regular_grid_value_for_level(octree_list)).astype("int8")
 
     # ===========
     if plot_pyvista or False:
@@ -86,7 +87,7 @@ def test_octree_lvl_collapse(simple_model, simple_grid_3d_octree):
     for i in range(len(octree_list)):
         shape = octree_list[i].grid.octree_grid_shape
         slice = shape[1] // 2
-        regular_grid_scalar = get_regular_grid_value_for_level(octree_list, level=i).astype("int8")
+        regular_grid_scalar = BackendTensor.t.to_numpy(get_regular_grid_value_for_level(octree_list, level=i)).astype("int8")
         plt.imshow(regular_grid_scalar[:, slice, :].T, origin="lower")
         plt.colorbar()
         plt.show()


### PR DESCRIPTION
- Added automatic PyTorch tensor conversion in `_repeat()` to ensure compatibility with GPU.
- Updated `_to_numpy()` to check tensor type explicitly before handling CUDA tensors.
- Replaced `engine_backend` check with `is_pytorch_installed` for clarity.
- Refactored plotting helpers to leverage `BackendTensor.t` for consistent tensor-to-NumPy conversions.
- Enhanced test fixtures to restore `BackendTensor` state after use.