### PR TITLE
feat(dual_contouring): refactor backend tensor usage and add fault overlap threading option

### DIFF
--- a/gempy_engine/config.py
+++ b/gempy_engine/config.py
@@ -37,6 +37,7 @@ LINE_PROFILER_ENABLED = os.getenv('LINE_PROFILER_ENABLED', 'False') == 'True'
 SET_RAW_ARRAYS_IN_SOLUTION = os.getenv('SET_RAW_ARRAYS_IN_SOLUTION', 'True') == 'True'
 NOT_MAKE_INPUT_DEEP_COPY = os.getenv('NOT_MAKE_INPUT_DEEP_COPY', 'False') == 'True'
 DUAL_CONTOURING_VERTEX_OVERLAP = DualContouringOverlap[os.getenv('DUAL_CONTOURING_VERTEX_OVERLAP', 'none')]
+DUAL_CONTOURING_FAULT_OVERLAP_THREADING = os.getenv('DUAL_CONTOURING_FAULT_OVERLAP_THREADING', 'True') == 'True'
 
 is_numpy_installed = find_spec("numpy") is not None
 is_tensorflow_installed = find_spec("tensorflow") is not None

--- a/gempy_engine/modules/dual_contouring/apply_mesh_modifications.py
+++ b/gempy_engine/modules/dual_contouring/apply_mesh_modifications.py
@@ -1,6 +1,8 @@
 from typing import List, Dict, TYPE_CHECKING
 import numpy as np
 
+from ...core.backend_tensor import BackendTensor
+
 if TYPE_CHECKING:
     from ...core.data.dual_contouring_mesh import DualContouringMesh
 
@@ -88,7 +90,7 @@ def remove_triangles_in_voxels(
         return
 
     # Build a boolean mask for vertex indices that are in the overlap
-    is_overlap_vertex = np.zeros(mesh.vertices.shape[0], dtype=bool)
+    is_overlap_vertex = BackendTensor.t.zeros(mesh.vertices.shape[0], dtype=bool)
     is_overlap_vertex[voxel_indices] = True
 
     faces = mesh.edges

--- a/gempy_engine/modules/dual_contouring/overlapping.py
+++ b/gempy_engine/modules/dual_contouring/overlapping.py
@@ -4,6 +4,7 @@ from typing import List
 
 import numpy as np
 
+from gempy_engine.config import DUAL_CONTOURING_FAULT_OVERLAP_THREADING, AvailableBackends
 from gempy_engine.core.backend_tensor import BackendTensor
 from gempy_engine.core.data.dual_contouring_mesh import DualContouringMesh
 from gempy_engine.modules.dual_contouring.apply_mesh_modifications import remove_triangles_in_voxels
@@ -172,19 +173,21 @@ def remove_fault_overlap_triangles(
     # 3. Process each destination mesh entirely in its own thread
     def _process_destination_mesh(di: int, fault_indices: List[int]):
         # Combine all fault codes targeting this mesh into one array
-        combined_fault_codes = np.concatenate([codes[fi] for fi in fault_indices])
+        combined_fault_codes = BackendTensor.t.concatenate([codes[fi] for fi in fault_indices])
 
         # Fast unique to reduce intersection workload
-        unique_fault_codes = np.unique(combined_fault_codes)
+        unique_fault_codes = BackendTensor.t.unique(combined_fault_codes)
 
         # assume_unique=True is safe here if codes[di] has no internal duplicates
-        common = np.intersect1d(codes[di], unique_fault_codes, assume_unique=True)
+        common = BackendTensor.t.intersect1d(codes[di], unique_fault_codes, assume_unique=True)
+        if BackendTensor.engine_backend == AvailableBackends.PYTORCH:
+            common = common[0]
 
         if common.size == 0:
             return
 
-        mask_d = np.isin(codes[di], common)
-        dest_voxel_indices = np.where(mask_d)[0]
+        mask_d = BackendTensor.t.isin(codes[di], common)
+        dest_voxel_indices =  BackendTensor.t.where(mask_d)[0]
 
         # Execute the heavy mesh mutation INSIDE the thread. 
         # Since each thread works on a different 'di', this is entirely thread-safe!
@@ -194,11 +197,17 @@ def remove_fault_overlap_triangles(
             mode='all'
         )
 
+    if not DUAL_CONTOURING_FAULT_OVERLAP_THREADING or False:
+        for di, faults in dest_to_faults.items():
+            _process_destination_mesh(di, faults)
+        return
+
     # 4. Launch the threads
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [
                 executor.submit(_process_destination_mesh, di, faults)
                 for di, faults in dest_to_faults.items()
         ]
-        # Wait for all mesh mutations to finish
-        concurrent.futures.wait(futures)
+        # Calling result() propagates worker exceptions to the caller/debugger.
+        for future in concurrent.futures.as_completed(futures):
+            future.result()


### PR DESCRIPTION
Replaces NumPy operations with `BackendTensor` to support configurable backends across mesh modification and fault code processing. Introduces `DUAL_CONTOURING_FAULT_OVERLAP_THREADING` for optional threaded execution in fault overlap handling. Refines thread-safe execution logic and error propagation in multithreaded workflows.