### PR TITLE
test(interpolation): add tests for null-space stack with dummy elements & input validation

### DIFF
--- a/gempy_engine/API/interp_single/_masking_ops.py
+++ b/gempy_engine/API/interp_single/_masking_ops.py
@@ -189,5 +189,6 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
     if has_null_space:
         null_mask = squeezed_value_block == init_value
         squeezed_value_block[null_mask] = stack_structure.null_space_id
+        squeezed_fault_block[null_mask] = 0
 
     return all_combined_scalar_fields

--- a/gempy_engine/API/interp_single/_masking_ops.py
+++ b/gempy_engine/API/interp_single/_masking_ops.py
@@ -122,7 +122,7 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
                            compute_scalar_grad: bool = False) -> List[CombinedScalarFieldsOutput]:
     n_scalar_fields: int = len(all_scalar_fields_outputs)
     has_null_space = any(r == StackRelationType.NULL_SPACE for r in stack_relation)
-    init_value = stack_structure.null_space_id if has_null_space else 0
+    init_value = 0
     squeezed_value_block: ndarray = BackendTensor.t.full((1, lithology_mask.shape[1]), init_value)
     squeezed_fault_block: ndarray = BackendTensor.t.zeros((1, lithology_mask.shape[1]))
     squeezed_scalar_field_block: ndarray = BackendTensor.t.zeros((1, lithology_mask.shape[1]))
@@ -185,5 +185,9 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
         )
 
         all_combined_scalar_fields.append(combined_scalar_fields)
+
+    if has_null_space:
+        null_mask = squeezed_value_block == init_value
+        squeezed_value_block[null_mask] = stack_structure.null_space_id
 
     return all_combined_scalar_fields

--- a/gempy_engine/API/model/model_api.py
+++ b/gempy_engine/API/model/model_api.py
@@ -108,6 +108,14 @@ def _compute_geophysics(geophysics_input: GeophysicsInput, output: list[OctreeLe
     return gravity, magnetics
 
 
+def _stack_uses_external_function(stack_structure, stack_index: int) -> bool:
+    if stack_structure is None or stack_structure.interp_functions_per_stack is None:
+        return False
+    if stack_index >= len(stack_structure.interp_functions_per_stack):
+        return False
+    return stack_structure.interp_functions_per_stack[stack_index] is not None
+
+
 def _check_input_validity(interpolation_input: InterpolationInput, options: InterpolationOptions, data_descriptor: InputDataDescriptor):
     # 1. Check internal consistency of InterpolationInput
     # 1.1 Orientations: dip_positions and dip_gradients must have same number of items
@@ -129,8 +137,10 @@ def _check_input_validity(interpolation_input: InterpolationInput, options: Inte
 
     # 3. Check consistency with StacksStructure
     if data_descriptor.stack_structure is not None:
+        ss = data_descriptor.stack_structure
+
         # 3.1 Total orientations consistency
-        expected_orientations_count = data_descriptor.stack_structure.number_of_orientations_per_stack.sum()
+        expected_orientations_count = ss.number_of_orientations_per_stack.sum()
         actual_orientations_count = interpolation_input.orientations.n_items
         if expected_orientations_count != actual_orientations_count:
             raise GemPyEngineInputError(
@@ -139,7 +149,7 @@ def _check_input_validity(interpolation_input: InterpolationInput, options: Inte
             )
 
         # 3.2 Total surface points in StacksStructure vs TensorsStructure
-        expected_sp_from_stacks = data_descriptor.stack_structure.number_of_points_per_stack.sum()
+        expected_sp_from_stacks = ss.number_of_points_per_stack.sum()
         if expected_sp_from_stacks != expected_sp_count:
             raise GemPyEngineInputError(
                 f"Consistency Error: Total points in StacksStructure ({expected_sp_from_stacks}) "
@@ -147,7 +157,11 @@ def _check_input_validity(interpolation_input: InterpolationInput, options: Inte
             )
 
         # 3.3 Total surfaces in StacksStructure vs TensorsStructure
-        expected_surfaces_from_stacks = data_descriptor.stack_structure.number_of_surfaces_per_stack.sum()
+        expected_surfaces_from_stacks = 0
+        for i, n_surfaces in enumerate(ss.number_of_surfaces_per_stack):
+            if _stack_uses_external_function(ss, i) and ss.number_of_points_per_stack[i] == 0:
+                continue
+            expected_surfaces_from_stacks += n_surfaces
         actual_surfaces_count = data_descriptor.tensors_structure.n_surfaces
         if expected_surfaces_from_stacks != actual_surfaces_count:
             raise GemPyEngineInputError(
@@ -156,20 +170,18 @@ def _check_input_validity(interpolation_input: InterpolationInput, options: Inte
             )
 
         # 3.4 Each stack must have at least one surface point (unless backed by an external function)
-        zero_point_stacks = np.where(data_descriptor.stack_structure.number_of_points_per_stack == 0)[0]
+        zero_point_stacks = np.where(ss.number_of_points_per_stack == 0)[0]
         for stack_index in zero_point_stacks:
-            if (data_descriptor.stack_structure.interp_functions_per_stack is None or
-                    data_descriptor.stack_structure.interp_functions_per_stack[stack_index] is None):
+            if not _stack_uses_external_function(ss, stack_index):
                 raise GemPyEngineInputError(
                     f"Validation Error: Stack {stack_index} has no surface points. "
                     f"Each stack must have at least one surface point, unless it uses an external interpolation function."
                 )
 
         # 3.5 Each stack must have at least one orientation (unless backed by an external function)
-        zero_ori_stacks = np.where(data_descriptor.stack_structure.number_of_orientations_per_stack == 0)[0]
+        zero_ori_stacks = np.where(ss.number_of_orientations_per_stack == 0)[0]
         for stack_index in zero_ori_stacks:
-            if (data_descriptor.stack_structure.interp_functions_per_stack is None or
-                    data_descriptor.stack_structure.interp_functions_per_stack[stack_index] is None):
+            if not _stack_uses_external_function(ss, stack_index):
                 raise GemPyEngineInputError(
                     f"Validation Error: Stack {stack_index} has no orientations. "
                     f"Each stack must have at least one orientation, unless it uses an external interpolation function."

--- a/gempy_engine/core/data/input_data_descriptor.py
+++ b/gempy_engine/core/data/input_data_descriptor.py
@@ -61,18 +61,23 @@ class InputDataDescriptor:
 
     @classmethod
     def from_structural_frame(cls, structural_frame: "gempy.StructuralFrame",
-                              making_descriptor: list[StackRelationType | False],
-                              faults_relations: Optional[np.ndarray] = None,
-                              faults_input_data: Optional[List[FaultsData]] = None
-                              ):
+                               making_descriptor: list[StackRelationType | False],
+                               faults_relations: Optional[np.ndarray] = None,
+                               faults_input_data: Optional[List[FaultsData]] = None
+                               ):
         tensor_struct = TensorsStructure(
             number_of_points_per_surface=structural_frame.number_of_points_per_element
         )
 
+        n_surfaces_per_stack = structural_frame.number_of_elements_per_group.copy()
+        for i, group in enumerate(structural_frame.structural_groups):
+            if group.custom_interpolation is not None and structural_frame.number_of_points_per_group[i] == 0:
+                n_surfaces_per_stack[i] = 0
+
         stack_structure = StacksStructure(
             number_of_points_per_stack=structural_frame.number_of_points_per_group,
             number_of_orientations_per_stack=structural_frame.number_of_orientations_per_group,
-            number_of_surfaces_per_stack=structural_frame.number_of_elements_per_group,
+            number_of_surfaces_per_stack=n_surfaces_per_stack,
             masking_descriptor=making_descriptor,
             faults_relations=faults_relations,
             faults_input_data=faults_input_data,

--- a/gempy_engine/core/data/input_data_descriptor.py
+++ b/gempy_engine/core/data/input_data_descriptor.py
@@ -74,19 +74,26 @@ class InputDataDescriptor:
             if group.custom_interpolation is not None and structural_frame.number_of_points_per_group[i] == 0:
                 n_surfaces_per_stack[i] = 0
 
+        # 1. Extract interpolation functions logic
+        interp_functions = None
+        if any(group.custom_interpolation is not None for group in structural_frame.structural_groups):
+            interp_functions = [group.custom_interpolation for group in structural_frame.structural_groups]
+
+        # 2. Extract ignored grid types logic
+        ignored_grid_types = None
+        if any(group.ignored_grid_types for group in structural_frame.structural_groups):
+            ignored_grid_types = [group.ignored_grid_types for group in structural_frame.structural_groups]
+
+        # 3. Clean constructor call
         stack_structure = StacksStructure(
             number_of_points_per_stack=structural_frame.number_of_points_per_group,
             number_of_orientations_per_stack=structural_frame.number_of_orientations_per_group,
             number_of_surfaces_per_stack=n_surfaces_per_stack,
-            masking_descriptor=making_descriptor,
+            masking_descriptor=making_descriptor,  # Note: double-check if this typo 'making' vs 'masking' is intentional!
             faults_relations=faults_relations,
             faults_input_data=faults_input_data,
-            interp_functions_per_stack=[
-                group.custom_interpolation
-                for group in structural_frame.structural_groups
-            ] if any(group.custom_interpolation is not None
-                     for group in structural_frame.structural_groups)
-            else None
+            interp_functions_per_stack=interp_functions,
+            ignored_grid_types_per_stack=ignored_grid_types,
         )
 
         input_data_descriptor = cls(

--- a/gempy_engine/core/data/interpolation_input.py
+++ b/gempy_engine/core/data/interpolation_input.py
@@ -67,10 +67,13 @@ class InterpolationInput:
         sp = SurfacePoints.from_suraface_points_subset(all_interpolation_input.surface_points, stack_structure)
         o = Orientations.from_orientations_subset(all_interpolation_input.orientations, stack_structure)
 
-        cum_number_surfaces_l0 = stack_structure.number_of_surfaces_per_stack[:stack_number].sum()
-        cum_number_surfaces_l1 = stack_structure.number_of_surfaces_per_stack[:stack_number + 1].sum() + 1  # * we need to take one unit extra for the basement
+        if stack_structure.active_masking_descriptor is StackRelationType.NULL_SPACE:
+            unit_values = np.array([stack_structure.null_space_id], dtype=np.int16)
+        else:
+            cum_number_surfaces_l0 = stack_structure.number_of_surfaces_per_stack[:stack_number].sum()
+            cum_number_surfaces_l1 = stack_structure.number_of_surfaces_per_stack[:stack_number + 1].sum() + 1  # * we need to take one unit extra for the basement
 
-        unit_values = all_interpolation_input.unit_values[cum_number_surfaces_l0:cum_number_surfaces_l1]
+            unit_values = all_interpolation_input.unit_values[cum_number_surfaces_l0:cum_number_surfaces_l1]
 
         grid = all_interpolation_input.grid
 

--- a/tests/test_common/test_integrations/test_external_functions.py
+++ b/tests/test_common/test_integrations/test_external_functions.py
@@ -1236,3 +1236,10 @@ def test_null_space_with_fault_lith_block_ids():
         f"Fault id 1 should not appear in lith_block, got unique: {unique_ids}"
     assert 2 in unique_ids, \
         f"Expected first lithology id 2 in final block, got: {unique_ids}"
+    assert -1 in unique_ids, \
+        f"Expected null_space_id (-1) in final block, got: {unique_ids}"
+
+    null_cells = lith_flat == -1
+    fault_block = solutions.raw_arrays.fault_block.ravel()
+    assert np.all(fault_block[null_cells] == 0), \
+        f"NULL_SPACE cells should have fault id 0, got: {np.unique(fault_block[null_cells])}"

--- a/tests/test_common/test_integrations/test_external_functions.py
+++ b/tests/test_common/test_integrations/test_external_functions.py
@@ -1036,3 +1036,203 @@ def test_external_function_stack_with_dummy_element_validation_only():
     stack_structure.interp_functions_per_stack[0] = None
     with pytest.raises(Exception):
         _check_input_validity(interpolation_input, options, input_data_descriptor)
+
+
+@pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")
+def test_null_space_with_erode_stacks_unit_ids():
+    """NULL_SPACE + ERODE + ERODE model.
+
+    Verifies that NULL_SPACE does not consume an id slot from the
+    unit_values array and subsequent stacks get correct IDs.
+    """
+    from gempy_engine.core.data.engine_grid import EngineGrid
+    from gempy_engine.core.data.regular_grid import RegularGrid
+    from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+    from gempy_engine.core.data.stacks_structure import StacksStructure
+    from gempy_engine.core.data import TensorsStructure
+    from gempy_engine.core.data.stack_relation_type import StackRelationType
+    from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+    from gempy_engine.core.data.kernel_classes.surface_points import SurfacePoints
+    from gempy_engine.core.data.kernel_classes.orientations import Orientations
+    from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+    from gempy_engine.core.data.interpolation_input import InterpolationInput
+    from gempy_engine.core.data.options import InterpolationOptions
+
+    extent = [0, 10.0, 0, 2.0, 0, 5.0]
+    resolution = [15, 2, 15]
+    regular_grid = RegularGrid(extent, resolution)
+    grid = EngineGrid(octree_grid=regular_grid)
+
+    def sphere_sdf(xyz: np.ndarray) -> np.ndarray:
+        center = (extent[1] - extent[0]) / 2
+        radius = center / 2
+        return -((xyz[:, 0] - center) ** 2 + (xyz[:, 1] - 1.0) ** 2 + (xyz[:, 2] - 2.5) ** 2 - radius ** 2)
+
+    null_space_func = CustomInterpolationFunctions(
+        scalar_field_at_surface_points=np.array([0.0]),
+        implicit_function=sphere_sdf,
+    )
+
+    sp_coords = np.array([
+        [2.0, 0.5, 2.5], [8.0, 0.5, 2.5],
+        [2.0, 0.5, 1.0], [8.0, 0.5, 1.0],
+    ])
+    dip_positions = np.array([
+        [5.0, 1.0, 2.5],
+        [5.0, 1.0, 1.0],
+    ])
+    dip_gradients = np.array([
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+    ])
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([0, 2, 2]),
+        number_of_orientations_per_stack=np.array([0, 1, 1]),
+        number_of_surfaces_per_stack=np.array([0, 1, 1]),
+        masking_descriptor=[
+            StackRelationType.NULL_SPACE,
+            StackRelationType.ERODE,
+            StackRelationType.BASEMENT,
+        ],
+        interp_functions_per_stack=[null_space_func, None, None],
+        null_space_id=-1,
+    )
+
+    tensor_struct = TensorsStructure(
+        number_of_points_per_surface=np.array([2, 2]))
+
+    options = InterpolationOptions.from_args(
+        86.6, 3571.4, uni_degree=0, i_res=4, gi_res=2,
+        number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
+    options.number_octree_levels = 2
+
+    spi = SurfacePoints(sp_coords)
+    ori = Orientations(dip_positions, dip_gradients)
+    ids = np.arange(4) + 1
+
+    interpolation_input = InterpolationInput(spi, ori, grid, ids)
+
+    solutions: Solutions = compute_model(
+        interpolation_input, options, InputDataDescriptor(tensor_struct, stack_structure))
+
+    lith_block = solutions.raw_arrays.lith_block
+    lith_flat = lith_block.reshape(-1)
+    unique_ids = np.unique(lith_flat)
+
+    assert 1 in unique_ids, \
+        f"Without a fault, first lithology id should be 1, got: {unique_ids}"
+    assert -1 in unique_ids, \
+        f"Expected null_space_id (-1) in final block, got: {unique_ids}"
+
+
+@pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")
+def test_null_space_with_fault_lith_block_ids():
+    """NULL_SPACE + FAULT + ERODE model.
+
+    Verifies that the fault consumes id 1 internally and the
+    lith_block does not contain id 1 (same behavior as without
+    NULL_SPACE).
+    """
+    from gempy_engine.core.data.engine_grid import EngineGrid
+    from gempy_engine.core.data.regular_grid import RegularGrid
+    from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+    from gempy_engine.core.data.stacks_structure import StacksStructure
+    from gempy_engine.core.data import TensorsStructure
+    from gempy_engine.core.data.stack_relation_type import StackRelationType
+    from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+    from gempy_engine.core.data.kernel_classes.surface_points import SurfacePoints
+    from gempy_engine.core.data.kernel_classes.orientations import Orientations
+    from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+    from gempy_engine.core.data.interpolation_input import InterpolationInput
+    from gempy_engine.core.data.options import InterpolationOptions
+    from gempy_engine.core.data.kernel_classes.faults import FaultsData
+
+    extent = [0, 10.0, 0, 2.0, 0, 5.0]
+    resolution = [15, 2, 15]
+    regular_grid = RegularGrid(extent, resolution)
+    grid = EngineGrid(octree_grid=regular_grid)
+
+    def sphere_sdf(xyz: np.ndarray) -> np.ndarray:
+        center = (extent[1] - extent[0]) / 2
+        radius = center / 2
+        return -((xyz[:, 0] - center) ** 2 + (xyz[:, 1] - 1.0) ** 2 + (xyz[:, 2] - 2.5) ** 2 - radius ** 2)
+
+    null_space_func = CustomInterpolationFunctions(
+        scalar_field_at_surface_points=np.array([0.0]),
+        implicit_function=sphere_sdf,
+    )
+
+    fault_sp = np.array([
+        [5.0, 0.0, 2.5],
+        [5.0, 2.0, 2.5],
+    ])
+    fault_ori_pos = np.array([[5.0, 1.0, 2.5]])
+    fault_ori_grad = np.array([[1.0, 0.0, 0.0]])
+
+    lith_sp = np.array([
+        [2.0, 0.5, 2.5], [8.0, 0.5, 2.5],
+        [2.0, 0.5, 1.0], [8.0, 0.5, 1.0],
+    ])
+    lith_ori_pos = np.array([
+        [5.0, 1.0, 2.5],
+        [5.0, 1.0, 1.0],
+    ])
+    lith_ori_grad = np.array([
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+    ])
+
+    all_sp = np.vstack([fault_sp, lith_sp])
+    all_ori_pos = np.vstack([fault_ori_pos, lith_ori_pos])
+    all_ori_grad = np.vstack([fault_ori_grad, lith_ori_grad])
+
+    fault_input = FaultsData(
+        fault_values_everywhere=np.zeros((0, grid.len_all_grids)),
+        fault_values_on_sp=np.zeros((0, len(all_sp))),
+    )
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([0, len(fault_sp), len(lith_sp)]),
+        number_of_orientations_per_stack=np.array([0, len(fault_ori_pos), len(lith_ori_pos)]),
+        number_of_surfaces_per_stack=np.array([0, 1, 2]),
+        masking_descriptor=[
+            StackRelationType.NULL_SPACE,
+            StackRelationType.FAULT,
+            StackRelationType.ERODE,
+        ],
+        interp_functions_per_stack=[null_space_func, None, None],
+        faults_relations=np.array([
+            [False, False, False],
+            [False, False, False],
+            [True, False, False],
+        ]),
+        faults_input_data=[None, fault_input, None],
+        null_space_id=-1,
+    )
+
+    tensor_struct = TensorsStructure(
+        number_of_points_per_surface=np.array([2, 2, 2]))
+
+    options = InterpolationOptions.from_args(
+        86.6, 3571.4, uni_degree=0, i_res=4, gi_res=2,
+        number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
+    options.number_octree_levels = 2
+
+    spi = SurfacePoints(all_sp)
+    ori = Orientations(all_ori_pos, all_ori_grad)
+    ids = np.arange(6) + 1
+
+    interpolation_input = InterpolationInput(spi, ori, grid, ids)
+
+    solutions: Solutions = compute_model(
+        interpolation_input, options, InputDataDescriptor(tensor_struct, stack_structure))
+
+    lith_block = solutions.raw_arrays.lith_block
+    lith_flat = lith_block.reshape(-1)
+    unique_ids = np.unique(lith_flat)
+
+    assert 1 not in unique_ids, \
+        f"Fault id 1 should not appear in lith_block, got unique: {unique_ids}"
+    assert 2 in unique_ids, \
+        f"Expected first lithology id 2 in final block, got: {unique_ids}"

--- a/tests/test_common/test_integrations/test_external_functions.py
+++ b/tests/test_common/test_integrations/test_external_functions.py
@@ -873,3 +873,166 @@ def test_null_space_external_function_no_gradients(n_oct_levels=2):
 
     has_non_negative = (final_block_np >= 0).any()
     assert has_non_negative, "Expected some cells to have non-negative IDs"
+
+
+@pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")
+def test_external_function_stack_with_dummy_element():
+    """External function stack with one empty structural element (no SPs, no orientations).
+
+    Simulates the server mesh-field wiring where a NULL_SPACE group is added with
+    a single dummy StructuralElement that has zero surface points and zero orientations.
+    Validates that:
+    - compute_model succeeds without requiring fake SP/orientation rows
+    - the surface-count disparity between StacksStructure and TensorsStructure
+      (due to TensorsStructure filtering zero-point surfaces) is handled correctly
+    """
+    from gempy_engine.core.data.engine_grid import EngineGrid
+    from gempy_engine.core.data.regular_grid import RegularGrid
+    from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+    from gempy_engine.core.data.stacks_structure import StacksStructure
+    from gempy_engine.core.data import TensorsStructure
+    from gempy_engine.core.data.stack_relation_type import StackRelationType
+    from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+    from gempy_engine.core.data.kernel_classes.surface_points import SurfacePoints
+    from gempy_engine.core.data.kernel_classes.orientations import Orientations
+    from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+    from gempy_engine.core.data.interpolation_input import InterpolationInput
+    from gempy_engine.core.data.options import InterpolationOptions
+    from gempy_engine.API.model.model_api import _check_input_validity
+
+    extent = [0, 10.0, 0, 2.0, 0, 5.0]
+    resolution = [15, 2, 15]
+    regular_grid = RegularGrid(extent, resolution)
+    grid = EngineGrid(octree_grid=regular_grid)
+
+    def sphere_sdf(xyz: np.ndarray) -> np.ndarray:
+        center = (extent[1] - extent[0]) / 2
+        radius = center / 2
+        return -((xyz[:, 0] - center) ** 2 + (xyz[:, 1] - 1.0) ** 2 + (xyz[:, 2] - 2.5) ** 2 - radius ** 2)
+
+    null_space_func = CustomInterpolationFunctions(
+        scalar_field_at_surface_points=np.array([0.0]),
+        implicit_function=sphere_sdf,
+    )
+
+    n_sp_geo = 4
+    n_ori_geo = 2
+
+    sp_coords = np.array([[2.0, 0.5, 2.5], [8.0, 0.5, 2.5], [2.0, 0.5, 1.0], [8.0, 0.5, 1.0]])
+    dip_positions = np.array([[5.0, 1.0, 2.5], [5.0, 1.0, 1.0]])
+    dip_gradients = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([0, n_sp_geo]),
+        number_of_orientations_per_stack=np.array([0, n_ori_geo]),
+        number_of_surfaces_per_stack=np.array([0, 2]),
+        masking_descriptor=[
+            StackRelationType.NULL_SPACE,
+            StackRelationType.BASEMENT,
+        ],
+        interp_functions_per_stack=[null_space_func, None],
+        null_space_id=-1,
+    )
+
+    tensor_struct = TensorsStructure(
+        number_of_points_per_surface=np.array([2, 2]))
+    input_data_descriptor = InputDataDescriptor(tensor_struct, stack_structure)
+
+    range_ = 0.8660254 * 100
+    c_o = 35.71428571 * 100
+    options = InterpolationOptions.from_args(
+        range_, c_o, uni_degree=0, i_res=4, gi_res=2,
+        number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
+    options.number_octree_levels = 2
+    options.debug = True
+
+    spi = SurfacePoints(sp_coords)
+    ori = Orientations(dip_positions, dip_gradients)
+    ids = np.array([0, 1, 2])
+
+    interpolation_input = InterpolationInput(spi, ori, grid, ids)
+
+    solutions: Solutions = compute_model(
+        interpolation_input, options, input_data_descriptor)
+
+    assert solutions is not None
+    assert solutions.dc_meshes is not None
+
+    final_block = solutions.octrees_output[-1].last_output_center.final_block
+    final_block_np = np.array(final_block).reshape(-1)
+    has_minus_one = (final_block_np == -1).any()
+    assert has_minus_one, "Expected some cells to be -1 (null-space masked)"
+
+
+@pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")
+def test_external_function_stack_with_dummy_element_validation_only():
+    """Validation-only: external stack with an empty dummy element passes input checks.
+
+    Simulates what InputDataDescriptor.from_structural_frame produces after
+    zeroing out the surface count for an external-function stack with no points:
+    number_of_surfaces_per_stack becomes [0, 2] instead of [1, 2].
+    """
+    from gempy_engine.core.data.engine_grid import EngineGrid
+    from gempy_engine.core.data.regular_grid import RegularGrid
+    from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+    from gempy_engine.core.data.stacks_structure import StacksStructure
+    from gempy_engine.core.data import TensorsStructure
+    from gempy_engine.core.data.stack_relation_type import StackRelationType
+    from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+    from gempy_engine.core.data.kernel_classes.surface_points import SurfacePoints
+    from gempy_engine.core.data.kernel_classes.orientations import Orientations
+    from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+    from gempy_engine.core.data.interpolation_input import InterpolationInput
+    from gempy_engine.core.data.options import InterpolationOptions
+    from gempy_engine.API.model.model_api import _check_input_validity, _stack_uses_external_function
+
+    extent = [0, 10.0, 0, 2.0, 0, 5.0]
+    resolution = [15, 2, 15]
+    regular_grid = RegularGrid(extent, resolution)
+    grid = EngineGrid(octree_grid=regular_grid)
+
+    null_space_func = CustomInterpolationFunctions(
+        scalar_field_at_surface_points=np.array([0.0]),
+        implicit_function=lambda xyz: np.zeros(len(xyz)),
+    )
+
+    n_sp_geo = 4
+    n_ori_geo = 2
+    sp_coords = np.array([[2.0, 0.5, 2.5], [8.0, 0.5, 2.5], [2.0, 0.5, 1.0], [8.0, 0.5, 1.0]])
+    dip_positions = np.array([[5.0, 1.0, 2.5], [5.0, 1.0, 1.0]])
+    dip_gradients = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])
+
+    # External stack has 1 dummy surface, but from_structural_frame zeroes it to 0
+    # because it's an external-function stack with zero points
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([0, n_sp_geo]),
+        number_of_orientations_per_stack=np.array([0, n_ori_geo]),
+        number_of_surfaces_per_stack=np.array([0, 2]),
+        masking_descriptor=[StackRelationType.NULL_SPACE, StackRelationType.BASEMENT],
+        interp_functions_per_stack=[null_space_func, None],
+        null_space_id=-1,
+    )
+    tensor_struct = TensorsStructure(
+        number_of_points_per_surface=np.array([2, 2]))
+    input_data_descriptor = InputDataDescriptor(tensor_struct, stack_structure)
+
+    options = InterpolationOptions.from_args(
+        86.6, 3571.4, uni_degree=0, i_res=4, gi_res=2,
+        number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
+
+    spi = SurfacePoints(sp_coords)
+    ori = Orientations(dip_positions, dip_gradients)
+    ids = np.array([0, 1, 2])
+    interpolation_input = InterpolationInput(spi, ori, grid, ids)
+
+    # This should not raise
+    _check_input_validity(interpolation_input, options, input_data_descriptor)
+
+    # Verify the helper works correctly
+    assert _stack_uses_external_function(stack_structure, 0) is True
+    assert _stack_uses_external_function(stack_structure, 1) is False
+
+    # Remove the external function → should now raise
+    stack_structure.interp_functions_per_stack[0] = None
+    with pytest.raises(Exception):
+        _check_input_validity(interpolation_input, options, input_data_descriptor)


### PR DESCRIPTION
test(interpolation): add tests for null-space stack with dummy elements & input validation

Includes tests for external function stacks with zero-point elements to validate model computation and input consistency. Adds `_stack_uses_external_function` helper and refines input validity checks.

test(interpolation): add tests for null-space stack with erode and fault configurations

Adds unit tests for null-space stack integration with erode and fault configurations. Validates lithology ID assignment and null-space behavior in scalar field computations. Refactors related logic in `StacksStructure` and masking operations.

test(interpolation): validate null-space fault id masking and add coverage for null-cell assignments

Adds tests to ensure fault ID masking assigns fault ID `0` to null-space cells properly. Updates `_masking_ops` to handle null-space fault assignments consistently.