### PR TITLE
[ENH] Isolate external-function stacks as singleton chunks to prevent PyKeOps batching

### DIFF
--- a/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
+++ b/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
@@ -33,7 +33,9 @@ def interpolate_all_fields(interpolation_input: InterpolationInput, options: Int
     )
 
     if (os.getenv("GEMPY_FLAT_STACKS", "False").lower() in ("true", "1", "t", "y", "yes") and
-            BackendTensor.use_pykeops and not has_external_functions):
+            BackendTensor.use_pykeops 
+            # and not has_external_functions
+    ):
         all_scalar_fields_outputs: List[ScalarFieldOutput] = _interpolate_stack_flat(data_descriptor, interpolation_input, options)
     else:
         all_scalar_fields_outputs: List[ScalarFieldOutput] = _interpolate_stack(data_descriptor, interpolation_input, options)
@@ -164,13 +166,18 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
     faults_relations[j, i] == True means stack i depends on fault stack j.
     Stacks are processed in chunks where all stacks in a chunk have their
     fault dependencies already resolved by previous chunks.
+    
+    External-function stacks are always emitted as singleton chunks so they
+    are never batched into PyKeOps stacked solver/evaluator calls.
     """
 
     faults_relations = stack_structure.faults_relations
     masking_descriptor = stack_structure.masking_descriptor
     n_stacks = stack_structure.n_stacks
 
-    if faults_relations is None:
+    external_stacks = _get_external_stack_indices(stack_structure)
+
+    if faults_relations is None and not external_stacks:
         return [list(range(n_stacks))]
 
     fault_stacks = {i for i in range(n_stacks) if masking_descriptor[i] is StackRelationType.FAULT}
@@ -182,14 +189,22 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
     while remaining:
         chunk = []
         for i in sorted(remaining):
-            deps = {j for j in range(n_stacks) if faults_relations[j, i] and j in fault_stacks}
+            deps = set()
+            if faults_relations is not None:
+                deps = {j for j in range(n_stacks) if faults_relations[j, i] and j in fault_stacks}
             if deps.issubset(resolved):
                 chunk.append(i)
 
         if not chunk:
             raise RuntimeError("Circular fault dependency detected")
 
-        chunks.append(chunk)
+        normal = [i for i in chunk if i not in external_stacks]
+        external_subchunks = [[i] for i in chunk if i in external_stacks]
+
+        if normal:
+            chunks.append(normal)
+        chunks.extend(external_subchunks)
+
         remaining -= set(chunk)
         resolved.update(i for i in chunk if i in fault_stacks)
 
@@ -202,6 +217,10 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
 
     new_chunks = []
     for chunk in chunks:
+        if len(chunk) <= 1:
+            new_chunks.append(chunk)
+            continue
+
         current_sub_chunk = []
         current_chunk_cost = 0
         for stack_idx in chunk:
@@ -218,3 +237,9 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
     chunks = new_chunks
 
     return chunks
+
+
+def _get_external_stack_indices(stack_structure: StacksStructure) -> set[int]:
+    if stack_structure.interp_functions_per_stack is None:
+        return set()
+    return {i for i, f in enumerate(stack_structure.interp_functions_per_stack) if f is not None}

--- a/gempy_engine/API/interp_single/_stack_ops.py
+++ b/gempy_engine/API/interp_single/_stack_ops.py
@@ -2,6 +2,7 @@ import concurrent.futures
 
 from ._aux_faults_ops import _grab_stack_fault_data, _modify_faults_values_output
 from ._interp_scalar_field import _evaluate_sys_eq, compute_weights
+from ._interp_single_feature import interpolate_feature_with_external_function
 from ...config import AvailableBackends
 from ...core.backend_tensor import BackendTensor
 from ...core.data import TensorsStructure, SurfacePoints, Orientations, SurfacePointsInternals, OrientationsInternals
@@ -38,6 +39,10 @@ class InterpolationState:
 
 
 def process_chunk(state: InterpolationState, chunk: list[int]):
+    if _is_external_chunk(state.stack_structure, chunk):
+        _process_external_chunk(state, chunk)
+        return
+
     # region preparation - build inputs for this chunk
     chunk_interpolation_inputs: list[InterpolationInput] = []
     chunk_tensor_structs: list[TensorsStructure] = []
@@ -327,3 +332,34 @@ def input_preprocess_v2(data_shape: TensorsStructure, interpolation_input: Inter
     solver_input.weights_x0 = BackendTensor.t.array(interpolation_input.weights)
 
     return solver_input
+
+
+def _is_external_chunk(stack_structure: StacksStructure, chunk: list[int]) -> bool:
+    if stack_structure.interp_functions_per_stack is None:
+        return False
+    if len(chunk) != 1:
+        return False
+    return stack_structure.interp_functions_per_stack[chunk[0]] is not None
+
+
+def _process_external_chunk(state: InterpolationState, chunk: list[int]):
+    i = chunk[0]
+    state.stack_structure.stack_number = i
+
+    options_i = (state.stack_structure.interpolation_options
+                 if state.stack_structure.interpolation_options is not None
+                 else state.options)
+
+    interpolation_input_i: InterpolationInput = InterpolationInput.from_interpolation_input_subset(
+        all_interpolation_input=state.root_interpolation_input,
+        stack_structure=state.stack_structure
+    )
+
+    output: ScalarFieldOutput = interpolate_feature_with_external_function(
+        interpolation_input=interpolation_input_i,
+        options=options_i,
+        external_interp_funct=state.stack_structure.interp_function,
+        external_segment_funct=state.stack_structure.segmentation_function,
+    )
+
+    state.all_scalar_fields_outputs[i] = output

--- a/tests/test_common/test_integrations/test_external_functions.py
+++ b/tests/test_common/test_integrations/test_external_functions.py
@@ -1243,3 +1243,116 @@ def test_null_space_with_fault_lith_block_ids():
     fault_block = solutions.raw_arrays.fault_block.ravel()
     assert np.all(fault_block[null_cells] == 0), \
         f"NULL_SPACE cells should have fault id 0, got: {np.unique(fault_block[null_cells])}"
+
+
+class TestComputeIndependentChunks:
+    """Unit tests for _compute_independent_chunks external-stack isolation."""
+
+    @staticmethod
+    def _make_stack_structure(n_stacks, external_indices=None, faults_relations=None,
+                               masking_descriptor=None, n_points=None, n_orientations=None,
+                               n_surfaces=None):
+        from gempy_engine.core.data.stacks_structure import StacksStructure
+        from gempy_engine.core.data.stack_relation_type import StackRelationType
+        from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+
+        if n_points is None:
+            n_points = np.ones(n_stacks, dtype=int)
+        if n_orientations is None:
+            n_orientations = np.ones(n_stacks, dtype=int)
+        if n_surfaces is None:
+            n_surfaces = np.ones(n_stacks, dtype=int)
+        if masking_descriptor is None:
+            masking_descriptor = [StackRelationType.BASEMENT] * n_stacks
+
+        interp_functions = None
+        if external_indices is not None:
+            dummy_func = CustomInterpolationFunctions(
+                scalar_field_at_surface_points=np.array([0.0]),
+                implicit_function=lambda xyz: np.zeros(len(xyz)),
+            )
+            interp_functions = [
+                dummy_func if i in external_indices else None
+                for i in range(n_stacks)
+            ]
+
+        return StacksStructure(
+            number_of_points_per_stack=n_points,
+            number_of_orientations_per_stack=n_orientations,
+            number_of_surfaces_per_stack=n_surfaces,
+            masking_descriptor=masking_descriptor,
+            faults_relations=faults_relations,
+            interp_functions_per_stack=interp_functions,
+            null_space_id=-1,
+        )
+
+    def test_no_faults_no_external(self):
+        from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+
+        ss = self._make_stack_structure(n_stacks=4)
+        chunks = _compute_independent_chunks(ss, len_grid=100)
+        assert chunks == [[0, 1, 2, 3]]
+
+    def test_single_external_gets_its_own_chunk(self):
+        from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+
+        ss = self._make_stack_structure(n_stacks=3, external_indices={0})
+        chunks = _compute_independent_chunks(ss, len_grid=100)
+        assert chunks == [[1, 2], [0]], \
+            f"Expected external stack 0 as singleton, got {chunks}"
+
+    def test_multiple_externals_each_own_chunk(self):
+        from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+
+        ss = self._make_stack_structure(n_stacks=4, external_indices={0, 2})
+        chunks = _compute_independent_chunks(ss, len_grid=100)
+        assert [0] in chunks, f"External stack 0 should be singleton, got {chunks}"
+        assert [2] in chunks, f"External stack 2 should be singleton, got {chunks}"
+        assert [1, 3] in chunks, f"Normal stacks should be grouped, got {chunks}"
+
+    def test_external_with_fault_dependency_waits_for_fault(self):
+        from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+
+        ss = self._make_stack_structure(
+            n_stacks=3, external_indices={0},
+            masking_descriptor=[
+                StackRelationType.BASEMENT,
+                StackRelationType.FAULT,
+                StackRelationType.BASEMENT,
+            ],
+            faults_relations=np.array([
+                [False, False, False],
+                [False, False, False],
+                [True, False, False],
+            ]),
+        )
+        chunks = _compute_independent_chunks(ss, len_grid=100)
+        # Stack 1 (fault) can run independently of others
+        # Stack 2 depends on fault 1
+        # Stack 0 (external) also depends on fault 1
+        # Expected: [[1], [0, 2]] or [[1], [2, 0]]
+        assert len(chunks) == 2, f"Expected 2 chunks, got {chunks}"
+        assert 1 in chunks[0], f"Fault stack 1 should be first, got {chunks}"
+        assert 0 in chunks[1], f"External stack 0 should be in second chunk, got {chunks}"
+        assert [0] in [chunks[1]] or chunks[1] == [2, 0] or chunks[1] == [0, 2], \
+            f"External 0 should be a singleton in chunk 2, got {chunks}"
+
+    def test_no_external_behavior_unchanged(self):
+        from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+
+        ss = self._make_stack_structure(
+            n_stacks=3,
+            masking_descriptor=[
+                StackRelationType.ERODE,
+                StackRelationType.ERODE,
+                StackRelationType.BASEMENT,
+            ],
+            faults_relations=np.array([
+                [False, False, False],
+                [False, False, False],
+                [False, False, False],
+            ]),
+        )
+        chunks = _compute_independent_chunks(ss, len_grid=100)
+        assert chunks == [[0, 1, 2]], \
+            f"Without externals, all stacks should be in one chunk, got {chunks}"


### PR DESCRIPTION
Adds unit tests to validate chunk processing for external-function stacks in `_compute_independent_chunks`. Implements external stack isolation, ensuring singleton chunks for external stacks during interpolation. Updates chunking logic, adds `_is_external_chunk` and `_process_external_chunk` helpers, and refactors stack dependency resolution.