### PR TITLE
[FIX] Raise clear error for missing gradients in dual contouring and fix null-space mask assignment

### DIFF
--- a/gempy_engine/API/dual_contouring/multi_scalar_dual_contouring.py
+++ b/gempy_engine/API/dual_contouring/multi_scalar_dual_contouring.py
@@ -254,17 +254,29 @@ def _interp_on_edges(
 
     gradients = []
     slicer_idx_start = 0
+    stack_relations = data_descriptor.stack_structure.masking_descriptor
     for e, o in enumerate(output_on_edges):
         slicer_idx_end = slicer_idx_start + all_stack_intersection[e].shape[0]
         slicer = slice(slicer_idx_start, slicer_idx_end)
         ef = o.exported_fields
+        has_intersections = all_stack_intersection[e].shape[0] > 0
+        is_null_space = stack_relations[e] is StackRelationType.NULL_SPACE
         if ef.gx_field is not None:
             gradients.append(BackendTensor.t.stack((
                     ef.gx_field[slicer],
                     ef.gy_field[slicer],
                     ef.gz_field[slicer]
             ), axis=0).T)  # ! When we are computing the edges for dual contouring there is no surface points
+        elif is_null_space:
+            gradients.append(BackendTensor.t.zeros((0, 3), dtype=BackendTensor.dtype_obj))
         else:
+            if has_intersections:
+                raise ValueError(
+                    f"Dual contouring requires gradients for stack {e} "
+                    f"(stack_relation={stack_relations[e].name}), "
+                    "but the external interpolation function does not provide "
+                    "gx/gy/gz_function callbacks."
+                )
             gradients.append(BackendTensor.t.zeros((0, 3), dtype=BackendTensor.dtype_obj))
         slicer_idx_start = slicer_idx_end
 

--- a/gempy_engine/API/interp_single/_masking_ops.py
+++ b/gempy_engine/API/interp_single/_masking_ops.py
@@ -126,6 +126,7 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
     squeezed_value_block: ndarray = BackendTensor.t.full((1, lithology_mask.shape[1]), init_value)
     squeezed_fault_block: ndarray = BackendTensor.t.zeros((1, lithology_mask.shape[1]))
     squeezed_scalar_field_block: ndarray = BackendTensor.t.zeros((1, lithology_mask.shape[1]))
+    assigned_mask: ndarray = BackendTensor.t.zeros((1, lithology_mask.shape[1]), dtype=bool)
 
     def _apply_mask(block_to_squeeze: np.ndarray, squeezed_mask_array: np.ndarray, previous_block: np.ndarray) -> np.ndarray:
         return (previous_block + block_to_squeeze * squeezed_mask_array).reshape(-1)
@@ -142,6 +143,7 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
                 squeezed_mask_array=(lithology_mask[i]),
                 previous_block=squeezed_value_block
             )
+            assigned_mask = assigned_mask | lithology_mask[i]
 
         squeezed_scalar_field_block = _apply_mask(
             block_to_squeeze=interp_output.exported_fields.scalar_field,
@@ -187,7 +189,7 @@ def _combine_scalar_fields(all_scalar_fields_outputs: List[ScalarFieldOutput],
         all_combined_scalar_fields.append(combined_scalar_fields)
 
     if has_null_space:
-        null_mask = squeezed_value_block == init_value
+        null_mask = ~assigned_mask.reshape(-1)
         squeezed_value_block[null_mask] = stack_structure.null_space_id
         squeezed_fault_block[null_mask] = 0
 

--- a/tests/test_common/test_integrations/test_external_functions.py
+++ b/tests/test_common/test_integrations/test_external_functions.py
@@ -323,7 +323,7 @@ def test_tent_topography_external_function(n_oct_levels=2):
     # region: Plot (guarded)
     # ------------------------------------------------------------------
 
-    if PLOT or True:
+    if PLOT:
         dc_data = solutions.dc_meshes[0].dc_data
         helper_functions_pyvista.plot_pyvista(
             solutions.octrees_output,
@@ -562,7 +562,7 @@ def test_tent_topography_compute_solutions(n_oct_levels=2):
     # region: Plot (same pattern as test_dual_contouring_multiple_independent_fields)
     # ------------------------------------------------------------------
 
-    if PLOT or True:
+    if PLOT:
         tent_verts = np.array([[2.0, 0.0, 1.0], [8.0, 0.0, 1.0], [8.0, 2.0, 1.0], [2.0, 2.0, 1.0], [5.0, 1.0, 4.5]])
         tent_faces = np.array([[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]], dtype=np.int32)
         helper_functions_pyvista.plot_pyvista(
@@ -873,6 +873,69 @@ def test_null_space_external_function_no_gradients(n_oct_levels=2):
 
     has_non_negative = (final_block_np >= 0).any()
     assert has_non_negative, "Expected some cells to have non-negative IDs"
+
+
+@pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")
+def test_external_function_no_gradients_raises_on_mesh_extraction(n_oct_levels=2):
+    """Non-NULL_SPACE external function without gradient callbacks raises
+    a clear ValueError during mesh extraction when intersections exist."""
+    from gempy_engine.core.data.engine_grid import EngineGrid
+    from gempy_engine.core.data.regular_grid import RegularGrid
+    from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
+    from gempy_engine.core.data.stacks_structure import StacksStructure
+    from gempy_engine.core.data import TensorsStructure
+    from gempy_engine.core.data.stack_relation_type import StackRelationType
+    from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+    from gempy_engine.core.data.kernel_classes.surface_points import SurfacePoints
+    from gempy_engine.core.data.kernel_classes.orientations import Orientations
+    from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+    from gempy_engine.core.data.interpolation_input import InterpolationInput
+    from gempy_engine.core.data.options import InterpolationOptions
+
+    extent = [0, 10.0, 0, 2.0, 0, 5.0]
+    resolution = [15, 2, 15]
+    regular_grid = RegularGrid(extent, resolution)
+    grid = EngineGrid(octree_grid=regular_grid)
+
+    def sphere_sdf(xyz: np.ndarray) -> np.ndarray:
+        center = (extent[1] - extent[0]) / 2
+        radius = center / 2
+        return -((xyz[:, 0] - center) ** 2 + (xyz[:, 1] - 1.0) ** 2 + (xyz[:, 2] - 2.5) ** 2 - radius ** 2)
+
+    no_grad_func = CustomInterpolationFunctions(
+        scalar_field_at_surface_points=np.array([0.0]),
+        implicit_function=sphere_sdf,
+    )
+
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([0]),
+        number_of_orientations_per_stack=np.array([0]),
+        number_of_surfaces_per_stack=np.array([1]),
+        masking_descriptor=[StackRelationType.BASEMENT],
+        interp_functions_per_stack=[no_grad_func],
+    )
+
+    tensor_struct = TensorsStructure(
+        number_of_points_per_surface=np.array([0]))
+    input_data_descriptor = InputDataDescriptor(tensor_struct, stack_structure)
+
+    range_ = 0.8660254 * 100
+    c_o = 35.71428571 * 100
+    options = InterpolationOptions.from_args(
+        range_, c_o, uni_degree=0, i_res=4, gi_res=2,
+        number_dimensions=3, kernel_function=AvailableKernelFunctions.cubic)
+    options.number_octree_levels = n_oct_levels
+    options.evaluation_options.mesh_extraction_masking_options = \
+        MeshExtractionMaskingOptions.INTERSECT
+
+    spi = SurfacePoints(np.empty((0, 3)))
+    ori = Orientations(np.empty((0, 3)), np.empty((0, 3)))
+    ids = np.array([0])
+
+    interpolation_input = InterpolationInput(spi, ori, grid, ids)
+
+    with pytest.raises(ValueError, match="Dual contouring requires gradients"):
+        compute_model(interpolation_input, options, input_data_descriptor)
 
 
 @pytest.mark.skipif(TEST_SPEED.value <= 1, reason="Global test speed below this test value.")


### PR DESCRIPTION
Adds a test to validate that external interpolation functions without gradient callbacks raise clear errors during mesh extraction. Refines masking operations with an `assigned_mask` for consistent null-space handling in scalar fields. Enhances error handling in dual contouring for cases with missing gradients.