### PR TITLE
[FIX] for displaying meshes in Jupyter notebooks: Handle dc_meshes=None in Solutions repr methods

### DIFF
--- a/gempy_engine/core/data/solutions.py
+++ b/gempy_engine/core/data/solutions.py
@@ -47,10 +47,12 @@ class Solutions:
 
 
     def __repr__(self):
-        return f"Solutions({len(self.octrees_output)} Octree Levels, {len(self.dc_meshes)} DualContouringMeshes)"
+        n_meshes = len(self.dc_meshes) if self.dc_meshes is not None else 0
+        return f"Solutions({len(self.octrees_output)} Octree Levels, {n_meshes} DualContouringMeshes)"
 
     def _repr_html_(self):
-        return f"<b>Solutions:</b> {len(self.octrees_output)} Octree Levels, {len(self.dc_meshes)} DualContouringMeshes"
+        n_meshes = len(self.dc_meshes) if self.dc_meshes is not None else 0
+        return f"<b>Solutions:</b> {len(self.octrees_output)} Octree Levels, {n_meshes} DualContouringMeshes"
 
     @property
     def block_solution_resolution(self) -> np.ndarray:

--- a/tests/test_common/test_core/test_data_classes.py
+++ b/tests/test_common/test_core/test_data_classes.py
@@ -1,3 +1,28 @@
-from gempy_engine.core.data import TensorsStructure
+from types import SimpleNamespace
+
 import numpy as np
 
+from gempy_engine.core.data import TensorsStructure
+from gempy_engine.core.data.solutions import Solutions
+
+
+def _make_stub_octree_level():
+    # Minimal stand-in for an OctreeLevel: no scalar fields and no octree
+    # grid, which is what Solutions sees when meshes are not extracted.
+    return SimpleNamespace(outputs=[], grid=SimpleNamespace(octree_grid=None))
+
+
+def test_solutions_repr_with_meshes_none():
+    # With mesh_extraction=False (e.g. dense-grid interpolation options)
+    # dc_meshes is None; repr must not raise.
+    solutions = Solutions(octrees_output=[_make_stub_octree_level()], dc_meshes=None)
+
+    assert repr(solutions) == "Solutions(1 Octree Levels, 0 DualContouringMeshes)"
+    assert solutions._repr_html_() == "<b>Solutions:</b> 1 Octree Levels, 0 DualContouringMeshes"
+
+
+def test_solutions_repr_with_meshes():
+    solutions = Solutions(octrees_output=[_make_stub_octree_level()], dc_meshes=["mesh_a", "mesh_b"])
+
+    assert repr(solutions) == "Solutions(1 Octree Levels, 2 DualContouringMeshes)"
+    assert solutions._repr_html_() == "<b>Solutions:</b> 1 Octree Levels, 2 DualContouringMeshes"


### PR DESCRIPTION
When a model is computed with dense-grid interpolation options (mesh_extraction=False), Solutions.dc_meshes is None and displaying the object in Jupyter raised TypeError: object of type 'NoneType' has no len(). Report 0 DualContouringMeshes instead.