### PR TITLE
[FIX] Don't reference pykeops.torch when torch is not installed

### DIFF
--- a/gempy_engine/core/backend_tensor.py
+++ b/gempy_engine/core/backend_tensor.py
@@ -12,6 +12,16 @@ from gempy_engine.config import (is_pykeops_installed, is_numpy_installed, is_te
 if is_pykeops_installed:
     import pykeops.numpy
 
+    # pykeops only exposes its torch submodule when torch is installed
+    _LAZY_TENSOR_TYPES: tuple = (pykeops.numpy.LazyTensor,)
+    try:
+        import pykeops.torch
+        _LAZY_TENSOR_TYPES += (pykeops.torch.LazyTensor,)
+    except ImportError:
+        pass
+else:
+    _LAZY_TENSOR_TYPES = ()
+
 if is_pytorch_installed:
     import torch
 
@@ -386,7 +396,7 @@ class BackendTensor:
             match tensor:
                 case numpy.ndarray():
                     return numpy.exp(tensor)
-                case pykeops.numpy.LazyTensor() | pykeops.torch.LazyTensor():
+                case _ if isinstance(tensor, _LAZY_TENSOR_TYPES):
                     return tensor.exp()
                 case torch.Tensor() if torch_available:
                     return tensor.exp()
@@ -398,10 +408,7 @@ class BackendTensor:
                 return numpy.sum(tensor, axis=axis, keepdims=keepdims, dtype=dtype)
 
             # Handle LazyTensors (KeOps)
-            # We check for the attribute or common base if imports are tricky, 
-            # but explicit isinstance is safest if they are already in scope.
-            import pykeops
-            if isinstance(tensor, (pykeops.numpy.LazyTensor, pykeops.torch.LazyTensor)):
+            if isinstance(tensor, _LAZY_TENSOR_TYPES):
                 return tensor.sum(axis)
 
             if torch_available and isinstance(tensor, torch.Tensor):
@@ -415,8 +422,7 @@ class BackendTensor:
             if isinstance(tensor, numpy.ndarray):
                 return numpy.divide(tensor, other, dtype=dtype)
 
-            import pykeops
-            if isinstance(tensor, (pykeops.numpy.LazyTensor, pykeops.torch.LazyTensor)):
+            if isinstance(tensor, _LAZY_TENSOR_TYPES):
                 return tensor / other
 
             if torch_available and isinstance(tensor, torch.Tensor):
@@ -428,8 +434,7 @@ class BackendTensor:
             if isinstance(tensor, numpy.ndarray):
                 return numpy.sqrt(tensor)
 
-            import pykeops
-            if isinstance(tensor, (pykeops.numpy.LazyTensor, pykeops.torch.LazyTensor)):
+            if isinstance(tensor, _LAZY_TENSOR_TYPES):
                 return tensor.sqrt()
 
             if torch_available and isinstance(tensor, torch.Tensor):


### PR DESCRIPTION
## Problem

`gempy_engine/core/backend_tensor.py` imports only `pykeops.numpy` at the top (guarded by `is_pykeops_installed`), but the wrapped pykeops functions referenced `pykeops.torch.LazyTensor` unconditionally in four places (`_exp`, `_sum`, `_divide`, `_sqrt_fn`).

pykeops only exposes its `torch` submodule when torch is importable, so running the **numpy backend with pykeops enabled in an environment without torch** crashed with:

```
AttributeError: module 'pykeops' has no attribute 'torch'
```

inside `_sum` (reached from `_kernels_assembler._compute_distances_generic`). Reproduced with gempy_engine 2026.0.3 running the Weisweiler model on macOS CPU (numpy backend + `DEFAULT_PYKEOPS=True`).

## Fix

Build a module-level `_LAZY_TENSOR_TYPES` tuple at import time that always contains `pykeops.numpy.LazyTensor` and adds `pykeops.torch.LazyTensor` only when `import pykeops.torch` succeeds. All four type checks now use that tuple; the redundant `import pykeops` statements inside the wrapped functions were removed.

## Verification

- In a venv with numpy + pykeops and **no torch**: on `main`, a script enabling the pykeops numpy backend and calling the four wrapped functions with a `pykeops.numpy.LazyTensor`-typed object reproduces the exact `AttributeError`; on this branch all four functions dispatch correctly and plain numpy arrays still take the numpy path.
- In an environment **with** torch + pykeops: `_LAZY_TENSOR_TYPES` contains both the numpy and torch LazyTensor classes, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)