### PR TITLE
[ENH] Add fault drift stabilization with equilibration and relative diagonal regularization

### DIFF
--- a/gempy_engine/API/interp_single/_interp_scalar_field.py
+++ b/gempy_engine/API/interp_single/_interp_scalar_field.py
@@ -17,6 +17,7 @@ from ...modules.kernel_constructor._kernels_assembler import create_cov_kernel
 from ...modules.kernel_constructor._structs import KernelInput
 from ...modules.kernel_constructor._vectors_preparation import cov_vectors_preparation
 from ...modules.solver import solver_interface
+from ...modules.solver.fault_drift_stabilization import stabilize_fault_drift_system
 from ...modules.weights_cache.weights_cache_interface import WeightCache, generate_cache_key
 
 
@@ -81,6 +82,11 @@ def _solve_and_store_weights(solver_input, kernel_options, weights_key, weights_
 
 
 def _solve_interpolation(interp_input: SolverInput, kernel_options: KernelOptions) -> np.ndarray:
+    n_faults = interp_input.fault_internal.n_faults
+    if n_faults > 0:
+        # Stabilization requires direct access to the final fault rows and columns.
+        BackendTensor.pykeops_enabled = False
+
     kernel_data_tensor: KernelInput = cov_vectors_preparation(interp_input, kernel_options)
     if BackendTensor.pykeops_enabled:
         kernel_data: KernelInput = kernel_data_tensor.upgrade_tensors()
@@ -89,6 +95,13 @@ def _solve_interpolation(interp_input: SolverInput, kernel_options: KernelOption
 
     A_matrix = create_cov_kernel(kernel_data, kernel_options)
     b_vector = kernel_constructor.yield_b_vector(interp_input.ori_internal, A_matrix.shape[0])
+    fault_drift_scaling = stabilize_fault_drift_system(
+        covariance=A_matrix,
+        b_vector=b_vector,
+        n_faults=n_faults,
+        relative_regularization=kernel_options.fault_drift_regularization,
+        equilibrate=kernel_options.fault_drift_equilibration,
+    )
 
     if kernel_options.optimizing_condition_number:
         _optimize_nuggets_against_condition_number(A_matrix, interp_input, kernel_options)
@@ -104,14 +117,24 @@ def _solve_interpolation(interp_input: SolverInput, kernel_options: KernelOption
     if weights is None:  # * This can happen if we are using the pykeops solver and does not converge
         BackendTensor.pykeops_enabled = False
         A_matrix = create_cov_kernel(kernel_data_tensor, kernel_options)
+        b_vector = kernel_constructor.yield_b_vector(interp_input.ori_internal, A_matrix.shape[0])
+        fault_drift_scaling = stabilize_fault_drift_system(
+            covariance=A_matrix,
+            b_vector=b_vector,
+            n_faults=n_faults,
+            relative_regularization=kernel_options.fault_drift_regularization,
+            equilibrate=kernel_options.fault_drift_equilibration,
+        )
         weights = solver_interface.kernel_reduction(
             cov=A_matrix,
             b=b_vector,
             kernel_options=kernel_options,
             x0=interp_input.weights_x0
         )
-
         BackendTensor.pykeops_enabled = True
+
+    if fault_drift_scaling is not None:
+        weights = fault_drift_scaling.restore_weights(weights)
 
     if gempy_engine.config.DEBUG_MODE:
         # Save debug data for later

--- a/gempy_engine/core/data/options/kernel_options.py
+++ b/gempy_engine/core/data/options/kernel_options.py
@@ -25,9 +25,14 @@ class KernelOptions:
     optimizing_condition_number: bool = False
     condition_number: Optional[float] = None
 
+    fault_drift_equilibration: bool = True
+    fault_drift_regularization: float = 1e-3
+
     def __post_init__(self):
         self.range = float(self.range)
         self.c_o = float(self.c_o)
+        if self.fault_drift_regularization < 0:
+            raise ValueError("fault_drift_regularization must be non-negative")
 
     @field_validator('kernel_function', mode='before', json_schema_input_type=str)
     @classmethod
@@ -74,6 +79,8 @@ class KernelOptions:
             kernel_function (AvailableKernelFunctions, optional): The function used for the kernel. Defaults to AvailableKernelFunctions.exponential.
             compute_condition_number (bool, optional): Whether to compute the condition number. Defaults to False.
             kernel_solver (Solvers, optional): Solver for the kernel. Defaults to Solvers.DEFAULT.
+            fault_drift_equilibration (bool, optional): Scale fault rows and columns before solving. Defaults to True.
+            fault_drift_regularization (float, optional): Relative diagonal loading for fault coefficients. Defaults to 1e-3.
 
         Returns:
             None
@@ -98,6 +105,8 @@ class KernelOptions:
                 self.number_dimensions,
                 self.kernel_function,
                 self.compute_condition_number,
+                self.fault_drift_equilibration,
+                self.fault_drift_regularization,
         ))
 
     def __repr__(self):

--- a/gempy_engine/modules/solver/fault_drift_stabilization.py
+++ b/gempy_engine/modules/solver/fault_drift_stabilization.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from gempy_engine.core.backend_tensor import BackendTensor
+
+
+@dataclass
+class FaultDriftScaling:
+    factors: np.ndarray
+
+    def restore_weights(self, weights: np.ndarray) -> np.ndarray:
+        if weights.ndim == 1:
+            return weights * self.factors
+        return weights * self.factors[:, None]
+
+
+def stabilize_fault_drift_system(
+        covariance: np.ndarray,
+        b_vector: np.ndarray,
+        n_faults: int,
+        relative_regularization: float,
+        equilibrate: bool = True,
+) -> FaultDriftScaling | None:
+    """Equilibrate fault coefficient rows and add relative diagonal loading in place."""
+    if n_faults == 0:
+        return None
+    if relative_regularization < 0:
+        raise ValueError("relative_regularization must be non-negative")
+    if BackendTensor.pykeops_enabled:
+        raise ValueError("Fault drift stabilization requires a dense covariance matrix")
+
+    matrix_size = covariance.shape[0]
+    fault_start = matrix_size - n_faults
+    factors = BackendTensor.t.ones(matrix_size, dtype=BackendTensor.dtype_obj)
+
+    non_fault_block = covariance[:fault_start, :fault_start]
+    column_norms = BackendTensor.t.linalg.norm(non_fault_block, axis=0)
+    positive_column_norms = column_norms[column_norms > 0]
+    reference_norm = (
+        BackendTensor.t.median(positive_column_norms)
+        if positive_column_norms.shape[0] > 0
+        else BackendTensor.t.array(1.0, dtype=BackendTensor.dtype_obj)
+    )
+
+    if equilibrate:
+        for fault_index in range(n_faults):
+            matrix_index = fault_start + fault_index
+            fault_column_norm = BackendTensor.t.linalg.norm(covariance[:fault_start, matrix_index])
+            if fault_column_norm > 0:
+                factors[matrix_index] = reference_norm / fault_column_norm
+
+        covariance *= factors[:, None] * factors[None, :]
+        if b_vector.ndim == 1:
+            b_vector *= factors
+        else:
+            b_vector *= factors[:, None]
+
+    diagonal = BackendTensor.t.abs(BackendTensor.t.diag(non_fault_block))
+    positive_diagonal = diagonal[diagonal > 0]
+    matrix_scale = (
+        BackendTensor.t.median(positive_diagonal)
+        if positive_diagonal.shape[0] > 0
+        else reference_norm
+    )
+    regularization = relative_regularization * matrix_scale
+    fault_indices = BackendTensor.t.arange(fault_start, matrix_size)
+    covariance[fault_indices, fault_indices] -= regularization
+
+    return FaultDriftScaling(factors=factors)

--- a/tests/test_common/test_modules/test_solvers/test_fault_drift_stabilization.py
+++ b/tests/test_common/test_modules/test_solvers/test_fault_drift_stabilization.py
@@ -1,0 +1,98 @@
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from gempy_engine import compute_model
+from gempy_engine.config import AvailableBackends
+from gempy_engine.core.backend_tensor import BackendTensor
+from gempy_engine.core.data.options import KernelOptions
+from gempy_engine.modules.solver.fault_drift_stabilization import stabilize_fault_drift_system
+
+
+def _nearly_singular_fault_system():
+    covariance = BackendTensor.t.array([
+        [2.0, 0.2, 1e-8],
+        [0.2, 1.0, 2e-8],
+        [1e-8, 2e-8, 0.0],
+    ])
+    b_vector = BackendTensor.t.array([[1.0], [0.5], [0.0]])
+    return covariance, b_vector
+
+
+def test_fault_drift_equilibration_preserves_unregularized_solution():
+    covariance, b_vector = _nearly_singular_fault_system()
+    covariance_original = BackendTensor.t.copy(covariance)
+    b_vector_original = BackendTensor.t.copy(b_vector)
+    expected_weights = BackendTensor.t.linalg.solve(covariance_original, b_vector_original)
+
+    scaling = stabilize_fault_drift_system(
+        covariance=covariance,
+        b_vector=b_vector,
+        n_faults=1,
+        relative_regularization=0.0,
+    )
+    scaled_weights = BackendTensor.t.linalg.solve(covariance, b_vector)
+    actual_weights = scaling.restore_weights(scaled_weights)
+
+    np.testing.assert_allclose(
+        BackendTensor.t.to_numpy(actual_weights),
+        BackendTensor.t.to_numpy(expected_weights),
+        rtol=1e-6,
+    )
+    assert BackendTensor.t.linalg.cond(covariance) < BackendTensor.t.linalg.cond(covariance_original)
+
+
+def test_fault_drift_regularization_improves_conditioning_without_removing_large_offset():
+    covariance, b_vector = _nearly_singular_fault_system()
+    original_condition_number = BackendTensor.t.linalg.cond(covariance)
+    original_weights = BackendTensor.t.linalg.solve(covariance, b_vector)
+
+    scaling = stabilize_fault_drift_system(
+        covariance=covariance,
+        b_vector=b_vector,
+        n_faults=1,
+        relative_regularization=1e-3,
+    )
+    stabilized_weights = scaling.restore_weights(BackendTensor.t.linalg.solve(covariance, b_vector))
+
+    assert BackendTensor.t.linalg.cond(covariance) < original_condition_number
+    assert abs(stabilized_weights[-1, 0]) > 1e6
+    np.testing.assert_allclose(
+        BackendTensor.t.to_numpy(stabilized_weights[-1]),
+        BackendTensor.t.to_numpy(original_weights[-1]),
+        rtol=1e-2,
+    )
+
+
+def test_fault_drift_regularization_must_be_non_negative():
+    with pytest.raises(ValueError, match="must be non-negative"):
+        KernelOptions(range=1, c_o=1, fault_drift_regularization=-1e-3)
+
+
+def test_fault_drift_stabilization_in_graben_model(graben_fault_model):
+    baseline_input, baseline_structure, baseline_options = deepcopy(graben_fault_model)
+    baseline_options.evaluation_options.number_octree_levels = 1
+    baseline_options.evaluation_options.dual_contouring = False
+    baseline_options.kernel_options.compute_condition_number = True
+    baseline_options.kernel_options.fault_drift_equilibration = False
+    baseline_options.kernel_options.fault_drift_regularization = 0.0
+    baseline_solutions = compute_model(baseline_input, baseline_options, baseline_structure)
+    interpolation_input, structure, options = deepcopy(graben_fault_model)
+    options.evaluation_options.number_octree_levels = 1
+    options.evaluation_options.dual_contouring = False
+    options.kernel_options.compute_condition_number = True
+
+    solutions = compute_model(interpolation_input, options, structure)
+
+    scalar_field = solutions.octrees_output[-1].outputs[-1].exported_fields.scalar_field
+    baseline_scalar_field = baseline_solutions.octrees_output[-1].outputs[-1].exported_fields.scalar_field
+    assert np.isfinite(BackendTensor.t.to_numpy(scalar_field)).all()
+    assert np.isfinite(options.kernel_options.condition_number)
+    if BackendTensor.engine_backend is AvailableBackends.numpy:
+        np.testing.assert_allclose(
+            BackendTensor.t.to_numpy(scalar_field),
+            BackendTensor.t.to_numpy(baseline_scalar_field),
+            rtol=1e-5,
+            atol=1e-5,
+        )


### PR DESCRIPTION
Implements fault drift stabilization to improve interpolation reliability with dense covariance matrices. Introduces `fault_drift_equilibration` and `fault_drift_regularization` parameters to scale fault coefficient rows and apply relative diagonal loading. Adds unit tests to validate stabilization, regularization, and condition number improvements. Updates kernel and interpolation logic to integrate the stabilization process.