### PR TITLE
[ENH] Replace global `pykeops_enabled` flag with explicit `KernelExecutionMode` and extract solver routing into `interpolation_solver`

### DIFF
--- a/gempy_engine/API/interp_single/_interp_scalar_field.py
+++ b/gempy_engine/API/interp_single/_interp_scalar_field.py
@@ -18,7 +18,7 @@ from ...modules.solver.interpolation_solver import (
     solve_dense_fault_stabilized,
     solve_dense_ruiz,
     solve_dense_untransformed,
-    solve_pykeops_with_dense_fallback,
+    solve_pykeops_with_dense_fallback, InterpolationSolveResult,
 )
 from ...modules.weights_cache.weight_cache_policy import (
     WeightCacheRoute,
@@ -27,7 +27,8 @@ from ...modules.weights_cache.weight_cache_policy import (
 )
 
 
-def compute_weights(solver_input: Union[SolverInput, SolverInput_v2], stack_number: int, options: InterpolationOptions) -> ndarray[tuple[Any, ...], dtype[Any]]:
+def compute_weights(solver_input: Union[SolverInput, SolverInput_v2], stack_number: int, options: InterpolationOptions) \
+        -> ndarray[tuple[Any, ...], dtype[Any]]:
     pykeops_requested = pykeops_solver_requested()
     cache_decision = resolve_weight_cache(
         options=options,
@@ -41,7 +42,7 @@ def compute_weights(solver_input: Union[SolverInput, SolverInput_v2], stack_numb
         case WeightCacheRoute.SOLVE:
             return _solve_interpolation(solver_input, options.kernel_options, pykeops_requested)
         case WeightCacheRoute.SOLVE_AND_STORE:
-            result = _solve_interpolation_result(solver_input, options.kernel_options, pykeops_requested)
+            result: InterpolationSolveResult = _solve_interpolation_result(solver_input, options.kernel_options, pykeops_requested)
             if not result.used_fallback:
                 store_weight_result(cache_decision, result.weights)
             return result.weights
@@ -52,14 +53,15 @@ def _solve_interpolation(
         kernel_options: KernelOptions,
         pykeops_requested: bool | None = None,
 ) -> np.ndarray:
-    return _solve_interpolation_result(interp_input, kernel_options, pykeops_requested).weights
+    result: InterpolationSolveResult = _solve_interpolation_result(interp_input, kernel_options, pykeops_requested)
+    return result.weights
 
 
 def _solve_interpolation_result(
         interp_input: Union[SolverInput, SolverInput_v2],
         kernel_options: KernelOptions,
         pykeops_requested: bool | None = None,
-):
+) -> InterpolationSolveResult:
     pykeops_requested = pykeops_solver_requested() if pykeops_requested is None else pykeops_requested
     route = select_interpolation_solve_route(
         kernel_options=kernel_options,

--- a/gempy_engine/API/interp_single/_interp_scalar_field.py
+++ b/gempy_engine/API/interp_single/_interp_scalar_field.py
@@ -1,7 +1,4 @@
-import os
-import warnings
-from dataclasses import asdict
-from typing import Optional, Any, Union
+from typing import Any, Union
 
 import numpy as np
 from numpy import dtype, ndarray
@@ -13,249 +10,80 @@ from ...core.data.internal_structs import SolverInput, SolverInput_v2, Evaluator
 from ...core.data.options import KernelOptions, InterpolationOptions
 from ...modules.evaluator.generic_evaluator import generic_evaluator
 from ...modules.evaluator.symbolic_evaluator import symbolic_evaluator
-from ...modules.kernel_constructor import kernel_constructor_interface as kernel_constructor
-from ...modules.kernel_constructor._kernels_assembler import create_cov_kernel
-from ...modules.kernel_constructor._structs import KernelInput
-from ...modules.kernel_constructor._vectors_preparation import cov_vectors_preparation
-from ...modules.solver import solver_interface
-from ...modules.solver.fault_drift_stabilization import stabilize_fault_drift_system
-from ...modules.solver.linear_system_transform import (
-    add_fault_regularization,
-    equilibrate_symmetric_system,
-    normalized_residual,
+from ...modules.solver.interpolation_solver import (
+    InterpolationSolveRoute,
+    assemble_solve_debug,
+    pykeops_solver_requested,
+    select_interpolation_solve_route,
+    solve_dense_fault_stabilized,
+    solve_dense_ruiz,
+    solve_dense_untransformed,
+    solve_pykeops_with_dense_fallback,
 )
-from ...modules.weights_cache.weights_cache_interface import WeightCache, generate_cache_key
+from ...modules.weights_cache.weight_cache_policy import (
+    WeightCacheRoute,
+    resolve_weight_cache,
+    store_weight_result,
+)
 
 
 def compute_weights(solver_input: Union[SolverInput, SolverInput_v2], stack_number: int, options: InterpolationOptions) -> ndarray[tuple[Any, ...], dtype[Any]]:
-    weights_key = f"{options.cache_model_name}.{stack_number}"
-    weights_hash = None
-    cache_enabled = (
-        options.cache_mode in (InterpolationOptions.CacheMode.CACHE, InterpolationOptions.CacheMode.IN_MEMORY_CACHE)
-        and not BackendTensor.COMPUTE_GRADS
+    pykeops_requested = pykeops_solver_requested()
+    cache_decision = resolve_weight_cache(
+        options=options,
+        stack_number=stack_number,
+        pykeops_requested=pykeops_requested,
+        solver_input=solver_input,
     )
-    effective_cache_mode = (
-        options.cache_mode
-        if cache_enabled or options.cache_mode == InterpolationOptions.CacheMode.CLEAR_CACHE
-        else InterpolationOptions.CacheMode.NO_CACHE
+    match cache_decision.route:
+        case WeightCacheRoute.CACHED:
+            return cache_decision.weights
+        case WeightCacheRoute.SOLVE:
+            return _solve_interpolation(solver_input, options.kernel_options, pykeops_requested)
+        case WeightCacheRoute.SOLVE_AND_STORE:
+            result = _solve_interpolation_result(solver_input, options.kernel_options, pykeops_requested)
+            if not result.used_fallback:
+                store_weight_result(cache_decision, result.weights)
+            return result.weights
+
+
+def _solve_interpolation(
+        interp_input: Union[SolverInput, SolverInput_v2],
+        kernel_options: KernelOptions,
+        pykeops_requested: bool | None = None,
+) -> np.ndarray:
+    return _solve_interpolation_result(interp_input, kernel_options, pykeops_requested).weights
+
+
+def _solve_interpolation_result(
+        interp_input: Union[SolverInput, SolverInput_v2],
+        kernel_options: KernelOptions,
+        pykeops_requested: bool | None = None,
+):
+    pykeops_requested = pykeops_solver_requested() if pykeops_requested is None else pykeops_requested
+    route = select_interpolation_solve_route(
+        kernel_options=kernel_options,
+        n_faults=interp_input.fault_internal.n_faults,
+        pykeops_requested=pykeops_requested,
     )
-    match effective_cache_mode:
-        case InterpolationOptions.CacheMode.NO_CACHE:
-            weights_cached = None
-        case InterpolationOptions.CacheMode.CACHE | InterpolationOptions.CacheMode.IN_MEMORY_CACHE:
-            weights_cached: Optional[dict] = WeightCache.load_weights(
-                key=weights_key,
-                look_in_disk=not options.cache_mode == InterpolationOptions.CacheMode.IN_MEMORY_CACHE
-            )
-            ts = options.temp_interpolation_values.start_computation_ts
-            if ts == -1:
-                warnings.warn("No start computation timestamp found. No caching.")
-                weights_cached = None
-                cache_enabled = False
-            else:
-                weights_hash = generate_cache_key(
-                    name="",
-                    parameters={
-                            "schema": 2,
-                            "ts": ts,
-                            "kernel_options": _cacheable_kernel_options(options.kernel_options),
-                            "solver": repr(options.kernel_options.kernel_solver),
-                            "backend": repr(BackendTensor.engine_backend),
-                            "dtype": str(BackendTensor.dtype),
-                            "pykeops": os.getenv("PYKEOPS_SOLVER", "False") == "True",
-                    }
-                )
-        case InterpolationOptions.CacheMode.CLEAR_CACHE:
-            WeightCache.initialize_cache_dir()
-            weights_cached = None
-        case _:
-            raise ValueError("Cache mode not recognized")
+    match route:
+        case InterpolationSolveRoute.DENSE_UNTRANSFORMED:
+            result = solve_dense_untransformed(interp_input, kernel_options)
+        case InterpolationSolveRoute.DENSE_FAULT_STABILIZED:
+            result = solve_dense_fault_stabilized(interp_input, kernel_options)
+        case InterpolationSolveRoute.DENSE_RUIZ:
+            result = solve_dense_ruiz(interp_input, kernel_options)
+        case InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK:
+            result = solve_pykeops_with_dense_fallback(interp_input, kernel_options)
 
-    previous_pykeops_state = BackendTensor.pykeops_enabled
-    BackendTensor.pykeops_enabled = os.getenv("PYKEOPS_SOLVER", "False") == "True"
-    try:
-        match weights_cached:
-            case None:
-                weights = _solve_and_store_weights(
-                    solver_input=solver_input,
-                    kernel_options=options.kernel_options,
-                    weights_key=weights_key,
-                    weights_hash=weights_hash,
-                    store=cache_enabled,
-                )
-            case _ if weights_cached["hash"] != weights_hash:
-                weights = _solve_and_store_weights(
-                    solver_input=solver_input,
-                    kernel_options=options.kernel_options,
-                    weights_key=weights_key,
-                    weights_hash=weights_hash,
-                    store=cache_enabled,
-                )
-            case _ if weights_cached["hash"] == weights_hash:
-                weights = weights_cached["weights"]
-            case _:
-                raise ValueError("Something went wrong with the cache")
-        return weights
-    finally:
-        BackendTensor.pykeops_enabled = previous_pykeops_state
-
-
-def _cacheable_kernel_options(kernel_options):
-    parameters = asdict(kernel_options)
-    for runtime_field in ("condition_number", "condition_number_before", "condition_number_after"):
-        parameters.pop(runtime_field, None)
-    return parameters
-
-
-def _solve_and_store_weights(solver_input, kernel_options, weights_key, weights_hash, store):
-    weights = _solve_interpolation(solver_input, kernel_options)
-    if store:
-        WeightCache.store_weights(file_name=weights_key, hash=weights_hash, weights=weights)
-    return weights
-
-
-def _solve_interpolation(interp_input: SolverInput, kernel_options: KernelOptions) -> np.ndarray:
-    n_faults = interp_input.fault_internal.n_faults
-    requires_dense = n_faults > 0 or kernel_options.symmetric_equilibration_method != "none"
-    previous_pykeops_state = BackendTensor.pykeops_enabled
-    if requires_dense and previous_pykeops_state:
-        warnings.warn(
-            "Fault stabilization and symmetric equilibration require a dense system; disabling PyKeOps for this solve.",
-            RuntimeWarning,
-        )
-        BackendTensor.pykeops_enabled = False
-
-    try:
-        kernel_data_tensor: KernelInput = cov_vectors_preparation(interp_input, kernel_options)
-        kernel_data = kernel_data_tensor.upgrade_tensors() if BackendTensor.pykeops_enabled else kernel_data_tensor
-        physical_matrix, physical_rhs, transform = _build_transformed_system(
-            kernel_data, interp_input, kernel_options, n_faults
-        )
-        solve_matrix = transform.matrix if transform is not None else physical_matrix
-        solve_rhs = transform.rhs if transform is not None else physical_rhs
-
-        if kernel_options.optimizing_condition_number:
-            _optimize_nuggets_against_condition_number(solve_matrix, interp_input, kernel_options)
-
-        _record_condition_numbers(kernel_options, physical_matrix, solve_matrix)
-        scaled_initial_guess = (
-            transform.scale_initial_guess(interp_input.weights_x0)
-            if transform is not None
-            else interp_input.weights_x0
-        )
-        scaled_weights = solver_interface.kernel_reduction(
-            cov=solve_matrix,
-            b=solve_rhs,
-            kernel_options=kernel_options,
-            x0=scaled_initial_guess,
-        )
-
-        if scaled_weights is None:
-            BackendTensor.pykeops_enabled = False
-            physical_matrix, physical_rhs, transform = _build_transformed_system(
-                kernel_data_tensor, interp_input, kernel_options, n_faults
-            )
-            solve_matrix = transform.matrix if transform is not None else physical_matrix
-            solve_rhs = transform.rhs if transform is not None else physical_rhs
-            scaled_weights = solver_interface.kernel_reduction(
-                cov=solve_matrix,
-                b=solve_rhs,
-                kernel_options=kernel_options,
-                x0=(
-                    transform.scale_initial_guess(interp_input.weights_x0)
-                    if transform is not None
-                    else interp_input.weights_x0
-                ),
-            )
-
-        weights = transform.restore_weights(scaled_weights) if transform is not None else scaled_weights
-        residual = (
-            normalized_residual(physical_matrix, physical_rhs, weights)
-            if not BackendTensor.pykeops_enabled
-            else None
-        )
-
-        if gempy_engine.config.DEBUG_MODE:
-            from gempy_engine.core.data.solutions import Solutions
-            Solutions.debug_input_data.update({
-                "weights": weights,
-                "A_matrix": physical_matrix,
-                "b_vector": physical_rhs,
-                "A_matrix_physical": physical_matrix,
-                "b_vector_physical": physical_rhs,
-                "A_matrix_scaled": solve_matrix,
-                "b_vector_scaled": solve_rhs,
-                "scaling_factors": transform.factors if transform is not None else None,
-                "weights_scaled": scaled_weights,
-                "weights_physical": weights,
-                "condition_number_before": kernel_options.condition_number_before,
-                "condition_number_after": kernel_options.condition_number_after,
-                "normalized_residual": residual,
-                "equilibration_iterations": transform.iterations if transform is not None else 0,
-                "equilibration_converged": transform.converged if transform is not None else True,
-            })
-
-        return weights
-    finally:
-        BackendTensor.pykeops_enabled = previous_pykeops_state
-
-
-def _build_transformed_system(kernel_data, interp_input, kernel_options, n_faults):
-    physical_matrix = create_cov_kernel(kernel_data, kernel_options)
-    physical_rhs = kernel_constructor.yield_b_vector(interp_input.ori_internal, physical_matrix.shape[0])
-
-    if kernel_options.symmetric_equilibration_method == "ruiz":
-        transform = equilibrate_symmetric_system(
-            physical_matrix,
-            physical_rhs,
-            max_iterations=kernel_options.symmetric_equilibration_max_iterations,
-            tolerance=kernel_options.symmetric_equilibration_tolerance,
-        )
-        transform = add_fault_regularization(
-            transform,
-            n_faults=n_faults,
-            regularization=kernel_options.fault_drift_regularization,
-        )
-    elif n_faults:
-        transform = stabilize_fault_drift_system(
-            covariance=physical_matrix,
-            b_vector=physical_rhs,
-            n_faults=n_faults,
-            relative_regularization=kernel_options.fault_drift_regularization,
-            equilibrate=kernel_options.fault_drift_equilibration,
-        )
-    else:
-        transform = None
-    return physical_matrix, physical_rhs, transform
-
-
-def _record_condition_numbers(kernel_options, physical_matrix, scaled_matrix):
-    if not kernel_options.compute_condition_number or BackendTensor.pykeops_enabled:
-        return
-    before = BackendTensor.t.linalg.cond(physical_matrix)
-    after = BackendTensor.t.linalg.cond(scaled_matrix)
-    kernel_options.condition_number_before = before
-    kernel_options.condition_number_after = after
-    kernel_options.condition_number = after
-
-
-def _optimize_nuggets_against_condition_number(A_matrix, interp_input, kernel_options):
-    from ...core.data.continue_epoch import ContinueEpoch
-    import torch
-    cond_number = BackendTensor.t.linalg.cond(A_matrix)
-    nuggets = interp_input.sp_internal.nugget_effect_ref_rest
-    l1_reg = torch.norm(nuggets, 2) ** 2
-    lambda_l1 = 100_000_000
-    loss = cond_number - lambda_l1 * l1_reg
-    loss.backward()
-    kernel_options.condition_number = cond_number
-    print(f'Condition number: {cond_number}.')
-    raise ContinueEpoch()
+    if gempy_engine.config.DEBUG_MODE:
+        from gempy_engine.core.data.solutions import Solutions
+        Solutions.debug_input_data.update(assemble_solve_debug(result, kernel_options))
+    return result
 
 
 def _evaluate_sys_eq(eval_input: Union[SolverInput, EvaluatorInput], weights: np.ndarray, options: InterpolationOptions) -> ExportedFields:
-    BackendTensor.pykeops_enabled = BackendTensor.use_pykeops
-    if BackendTensor.pykeops_enabled:
+    if BackendTensor.use_pykeops:
         exported_fields = symbolic_evaluator(eval_input, weights, options)
     else:
         exported_fields = generic_evaluator(eval_input, weights, options)

--- a/gempy_engine/core/data/kernel_classes/kernel_functions.py
+++ b/gempy_engine/core/data/kernel_classes/kernel_functions.py
@@ -7,6 +7,10 @@ from enum import Enum
 from typing import Callable, Optional
 import numpy as np
 
+
+def _exp(values):
+    return values.exp() if hasattr(values, "exp") else np.exp(values)
+
 # ============================================================================
 # NumPy implementations (always available)
 # ============================================================================
@@ -69,17 +73,17 @@ def cubic_function_a_numpy(r: np.ndarray, a: float) -> np.ndarray:
 
 
 def exp_function_numpy(sq_r: np.ndarray, a: float) -> np.ndarray:
-    return np.exp(-(sq_r / (2.0 * a * a)))
+    return _exp(-(sq_r / (2.0 * a * a)))
 
 
 def exp_function_p_div_r_numpy(sq_r: np.ndarray, a: float) -> np.ndarray:
-    return -(1.0 / (a * a)) * np.exp(-(sq_r / (2.0 * a * a)))
+    return -(1.0 / (a * a)) * _exp(-(sq_r / (2.0 * a * a)))
 
 
 def exp_function_a_numpy(sq_r: np.ndarray, a: float) -> np.ndarray:
     a2 = a * a
     a4 = a2 * a2
-    return (sq_r / a4 - 1.0 / a2) * np.exp(-(sq_r / (2.0 * a2)))
+    return (sq_r / a4 - 1.0 / a2) * _exp(-(sq_r / (2.0 * a2)))
 
 
 def matern_function_5_2_numpy(r: np.ndarray, a: float) -> np.ndarray:
@@ -87,20 +91,20 @@ def matern_function_5_2_numpy(r: np.ndarray, a: float) -> np.ndarray:
     x = r / a
     s5_x = s5 * x
     poly = 1.0 + s5_x + (1.6666666667 * x * x)
-    return poly * np.exp(-s5_x)
+    return poly * _exp(-s5_x)
 
 
 def matern_function_5_2_p_div_r_numpy(r: np.ndarray, a: float) -> np.ndarray:
     s5 = 2.2360679775
     x = r / a
-    term_exp = np.exp(-s5 * x)
+    term_exp = _exp(-s5 * x)
     return -5.0 * term_exp * (a + s5 * r) / (3.0 * (a * a * a))
 
 
 def matern_function_5_2_a_numpy(r: np.ndarray, a: float) -> np.ndarray:
     s5 = 2.2360679775
     x = r / a
-    term_exp = np.exp(-s5 * x)
+    term_exp = _exp(-s5 * x)
     poly = (a * a) + (s5 * a * r) - (5.0 * r * r)
     return -5.0 * term_exp * poly / (3.0 * (a * a * a * a))
 

--- a/gempy_engine/modules/evaluator/symbolic_evaluator.py
+++ b/gempy_engine/modules/evaluator/symbolic_evaluator.py
@@ -11,6 +11,7 @@ from ...core.data import InterpolationOptions
 from ...core.data.exported_fields import ExportedFields
 from ...core.data.internal_structs import SolverInput, EvaluatorInput
 from ..kernel_constructor.kernel_constructor_interface import yield_evaluation_grad_kernel, yield_evaluation_kernel
+from ..kernel_constructor.execution_mode import KernelExecutionMode
 
 
 def symbolic_evaluator(solver_input: SolverInput, weights: np.ndarray, options: InterpolationOptions):
@@ -18,7 +19,7 @@ def symbolic_evaluator(solver_input: SolverInput, weights: np.ndarray, options: 
         print("xyz is not C_CONTIGUOUS")
     # ! Seems not to make any difference but we need this if we want to change the backend
     # ! We need to benchmark GPU vs CPU with more input
-    backend_string = BackendTensor.get_backend_string()
+    backend_string = "GPU" if BackendTensor.use_gpu else "CPU"
 
     eval_kernel = yield_evaluation_kernel(solver_input, options.kernel_options, pykeops=True)
     if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
@@ -97,7 +98,6 @@ def symbolic_evaluator_optimized_stacked(
 
     kernel_data_list = []
 
-    BackendTensor.pykeops_enabled = False
     # 2. Define a small wrapper function for the executor to map over
     def _run_prep(args):
         ei, axis, opt = args
@@ -120,12 +120,11 @@ def symbolic_evaluator_optimized_stacked(
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
         
-        original_pykeops_enabled = BackendTensor.pykeops_enabled
-        BackendTensor.pykeops_enabled = True
-        try:
-            eval_kernel_scalar = create_scalar_kernel(concat_kernel_data, base_options.kernel_options)
-        finally:
-            BackendTensor.pykeops_enabled = original_pykeops_enabled
+        eval_kernel_scalar = create_scalar_kernel(
+            concat_kernel_data,
+            base_options.kernel_options,
+            execution_mode=KernelExecutionMode.PYKEOPS,
+        )
 
     if base_options.compute_scalar_gradient is True:
         prep_tasks = []
@@ -141,12 +140,11 @@ def symbolic_evaluator_optimized_stacked(
 
         concat_kernel_data: KernelInput = _build_stacked_kernel_data(kernel_data_list)
         
-        original_pykeops_enabled = BackendTensor.pykeops_enabled
-        BackendTensor.pykeops_enabled = True
-        try:
-            eval_kernel_grad = create_grad_kernel(concat_kernel_data, base_options.kernel_options)
-        finally:
-            BackendTensor.pykeops_enabled = original_pykeops_enabled
+        eval_kernel_grad = create_grad_kernel(
+            concat_kernel_data,
+            base_options.kernel_options,
+            execution_mode=KernelExecutionMode.PYKEOPS,
+        )
 
     # region kernels
     match (base_options.compute_scalar, base_options.compute_scalar_gradient):
@@ -184,9 +182,10 @@ def symbolic_evaluator_optimized_stacked(
              if isinstance(eval_kernel, np.ndarray):
                  eval_kernel = LazyTensor(eval_kernel)
 
+        backend_string = "GPU" if BackendTensor.use_gpu else "CPU"
         all_results_concat: np.ndarray = (eval_kernel * lazy_weights).sum(
             axis=0,
-            backend=BackendTensor.get_backend_string(),
+            backend=backend_string,
             ranges=ranges
         ).reshape(-1)
     else:
@@ -196,9 +195,10 @@ def symbolic_evaluator_optimized_stacked(
                 all_weights = all_weights.to("cuda", non_blocking=True)
             lazy_weights = LazyTensor(all_weights.view((-1, 1)), axis=0)
 
+            backend_string = "GPU" if BackendTensor.use_gpu else "CPU"
             all_results_concat = (eval_kernel * lazy_weights).sum(
                 axis=0,
-                backend=BackendTensor.get_backend_string(),
+                backend=backend_string,
                 ranges=ranges
             ).reshape(-1)
 
@@ -267,8 +267,6 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
         OrientationSurfacePointsCoords, CartesianSelector, OrientationsDrift,
         PointsDrift, FaultDrift, DriftMatrixSelector, _cast_tensors
     )
-    BackendTensor.pykeops_enabled = True
-
     def _stack_sub_struct_split(items, cls):
         """Concatenate fields with explicitly split steps for easier profiling."""
         if items[0] is None:
@@ -395,5 +393,3 @@ def _build_stacked_kernel_data(kernel_data_list: list[KernelInput]) -> KernelInp
     stacked.nugget_grad = kernel_data_list[0].nugget_grad
 
     return stacked
-
-

--- a/gempy_engine/modules/evaluator/symbolic_evaluator.py
+++ b/gempy_engine/modules/evaluator/symbolic_evaluator.py
@@ -123,7 +123,7 @@ def symbolic_evaluator_optimized_stacked(
         eval_kernel_scalar = create_scalar_kernel(
             concat_kernel_data,
             base_options.kernel_options,
-            execution_mode=KernelExecutionMode.PYKEOPS,
+            execution_mode=KernelExecutionMode.SYMBOLIC,
         )
 
     if base_options.compute_scalar_gradient is True:
@@ -143,7 +143,7 @@ def symbolic_evaluator_optimized_stacked(
         eval_kernel_grad = create_grad_kernel(
             concat_kernel_data,
             base_options.kernel_options,
-            execution_mode=KernelExecutionMode.PYKEOPS,
+            execution_mode=KernelExecutionMode.SYMBOLIC,
         )
 
     # region kernels

--- a/gempy_engine/modules/kernel_constructor/_covariance_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_covariance_assembler.py
@@ -7,6 +7,7 @@ from gempy_engine.core.data.options import KernelOptions
 from gempy_engine.core.data.solutions import Solutions
 from gempy_engine.modules.kernel_constructor import _structs
 from gempy_engine.modules.kernel_constructor._structs import KernelInput
+from gempy_engine.modules.kernel_constructor.execution_mode import KernelExecutionMode
 
 # ! Important for loading the pickle in test_distance_matrix
 from gempy_engine.modules.kernel_constructor._internalDistancesMatrices import InternalDistancesMatrices
@@ -14,10 +15,23 @@ from gempy_engine.modules.kernel_constructor._internalDistancesMatrices import I
 global_nugget = 1e-5
 
 
-def get_covariance(c_o, dm, k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest, ki: KernelInput, options):
-    cov_grad = _get_cov_grad(dm, k_a, k_p_ref, ki.nugget_grad)
+def get_covariance(
+        c_o,
+        dm,
+        k_a,
+        k_p_ref,
+        k_p_rest,
+        k_ref_ref,
+        k_ref_rest,
+        k_rest_ref,
+        k_rest_rest,
+        ki: KernelInput,
+        options,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+):
+    cov_grad = _get_cov_grad(dm, k_a, k_p_ref, ki.nugget_grad, execution_mode)
     cov_sp = _get_cov_surface_points(dm, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest,
-                                     options, ki.nugget_scalar, ki.nugget_grad.shape[1])  # TODO: Add nugget effect properly (individual) # cov_sp += np.eye(cov_sp.shape[0]) * .00000001
+                                     options, ki.nugget_scalar, ki.nugget_grad.shape[1], execution_mode)  # TODO: Add nugget effect properly (individual) # cov_sp += np.eye(cov_sp.shape[0]) * .00000001
     cov_grad_sp = _get_cross_cov_grad_sp(dm, k_p_ref, k_p_rest, options)  # C
     
     # Universal drift
@@ -27,7 +41,7 @@ def get_covariance(c_o, dm, k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_res
 
     # Fault component
     if ki.ref_fault is not None:
-        faults_drift = _get_faults_terms(ki)
+        faults_drift = _get_faults_terms(ki, execution_mode)
         cov = c_o * (cov_grad + cov_sp + cov_grad_sp) + uni_drift + faults_drift  # *  NOTE: (miguel) The magic terms are real and now they are already included
     else:
         faults_drift = np.zeros(cov_grad.shape)
@@ -45,10 +59,16 @@ def get_covariance(c_o, dm, k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_res
     return cov
 
 
-def _get_cov_grad(dm, k_a, k_p_ref, nugget):
+def _get_cov_grad(
+        dm,
+        k_a,
+        k_p_ref,
+        nugget,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+):
     cov_grad = dm.hu * dm.hv / (dm.r_ref_ref ** 2 + 1e-5) * (- k_p_ref + k_a) - k_p_ref * dm.perp_matrix  # C
     grad_nugget = nugget[0, 0]
-    if BackendTensor.pykeops_enabled is False:
+    if execution_mode is KernelExecutionMode.DENSE:
         # eye = BackendTensor.t.array(np.eye(cov_grad.shape[0], dtype=BackendTensor.dtype))
         eye = BackendTensor.t.eye(cov_grad.shape[0])
         nugget_selector = eye * dm.perp_matrix
@@ -74,10 +94,20 @@ def _get_cov_grad(dm, k_a, k_p_ref, nugget):
     return cov_grad
 
 
-def _get_cov_surface_points(dm, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest, options: KernelOptions, nugget_effect, grad_matrix_size):
+def _get_cov_surface_points(
+        dm,
+        k_ref_ref,
+        k_ref_rest,
+        k_rest_ref,
+        k_rest_rest,
+        options: KernelOptions,
+        nugget_effect,
+        grad_matrix_size,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+):
     cov_surface_points = options.i_res * (k_rest_rest - k_rest_ref - k_ref_rest + k_ref_ref)
     
-    if BackendTensor.pykeops_enabled is False: # Add nugget effect for ref and rest point
+    if execution_mode is KernelExecutionMode.DENSE: # Add nugget effect for ref and rest point
         cov_shape = cov_surface_points.shape[0]
         shape_sp_size = nugget_effect.shape[0]
         
@@ -135,7 +165,10 @@ def _get_universal_gradient_terms(ki, options):
     return total_ug
 
 
-def _get_faults_terms(ki: KernelInput) -> np.ndarray:
+def _get_faults_terms(
+        ki: KernelInput,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> np.ndarray:
     fault_ref = (ki.ref_fault.faults_i * ki.ref_fault.faults_j).sum(axis=-1)
     fault_rest = (ki.rest_fault.faults_i * ki.rest_fault.faults_j).sum(axis=-1)
 
@@ -150,7 +183,7 @@ def _get_faults_terms(ki: KernelInput) -> np.ndarray:
         drift_start_post_y=cov_size - fault_n
     )
     
-    if BackendTensor.pykeops_enabled:
+    if execution_mode is KernelExecutionMode.PYKEOPS:
         selector_components = selector_components.upgrade_tensors()
     
     selector = (selector_components.sel_ui * (selector_components.sel_vj + 1)).sum(axis=-1)

--- a/gempy_engine/modules/kernel_constructor/_covariance_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_covariance_assembler.py
@@ -183,7 +183,7 @@ def _get_faults_terms(
         drift_start_post_y=cov_size - fault_n
     )
     
-    if execution_mode is KernelExecutionMode.PYKEOPS:
+    if execution_mode is KernelExecutionMode.SYMBOLIC:
         selector_components = selector_components.upgrade_tensors()
     
     selector = (selector_components.sel_ui * (selector_components.sel_vj + 1)).sum(axis=-1)

--- a/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
@@ -100,7 +100,7 @@ def create_scalar_kernel(
             drift_start_post_y=j_size
         )
 
-        if execution_mode is KernelExecutionMode.PYKEOPS:
+        if execution_mode is KernelExecutionMode.SYMBOLIC:
             selector_components = selector_components.upgrade_tensors()
 
         selector = bt.t.sum(selector_components.sel_ui * (selector_components.sel_vj + 1), axis=-1)
@@ -205,7 +205,7 @@ def _compute_distances_generic(
     if square_distance is False:
         # @off
         epsilon = 1e-10  # Add small regularization term to avoid numerical errors
-        if execution_mode is KernelExecutionMode.PYKEOPS:
+        if execution_mode is KernelExecutionMode.SYMBOLIC:
             r_ref_ref = (r_ref_ref + epsilon).sqrt()
             r_rest_rest = (r_rest_rest + epsilon).sqrt()
             r_ref_rest = (r_ref_rest + epsilon).sqrt()

--- a/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
@@ -2,6 +2,7 @@ from . import _structs
 from ._covariance_assembler import get_covariance
 from ._internalDistancesMatrices import InternalDistancesMatrices
 from ._structs import KernelInput, CartesianSelector, OrientationSurfacePointsCoords
+from .execution_mode import KernelExecutionMode
 from ...core.backend_tensor import BackendTensor as bt, BackendTensor
 from ...core.data.kernel_classes.kernel_functions import KernelFunction
 from ...core.data.options import KernelOptions
@@ -9,14 +10,19 @@ from ...core.data.options import KernelOptions
 tensor_types = bt.tensor_types
 
 
-def create_cov_kernel(ki: KernelInput, options: KernelOptions) -> tensor_types:
+def create_cov_kernel(
+        ki: KernelInput,
+        options: KernelOptions,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> tensor_types:
     kernel_f: KernelFunction = options.kernel_function.value
 
     distances_matrices = _compute_all_distance_matrices(
         cs=ki.cartesian_selector,
         ori_sp_matrices=ki.ori_sp_matrices,
         square_distance=kernel_f.consume_sq_distance,
-        is_gradient=False
+        is_gradient=False,
+        execution_mode=execution_mode,
     )
 
     kernels: tuple = _compute_all_kernel_terms(
@@ -28,13 +34,17 @@ def create_cov_kernel(ki: KernelInput, options: KernelOptions) -> tensor_types:
         r_rest_rest=distances_matrices.r_rest_rest
     )
 
-    cov = get_covariance(options.c_o, distances_matrices, *kernels, ki, options)
+    cov = get_covariance(options.c_o, distances_matrices, *kernels, ki, options, execution_mode)
 
     return cov
 
 
 # noinspection DuplicatedCode
-def create_scalar_kernel(ki: KernelInput, options: KernelOptions) -> tensor_types:
+def create_scalar_kernel(
+        ki: KernelInput,
+        options: KernelOptions,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> tensor_types:
     kernel_f = options.kernel_function.value
     a = options.range
     c_o = options.c_o
@@ -44,7 +54,8 @@ def create_scalar_kernel(ki: KernelInput, options: KernelOptions) -> tensor_type
         cs=ki.cartesian_selector,
         ori_sp_matrices=ki.ori_sp_matrices,
         square_distance=kernel_f.consume_sq_distance,
-        is_gradient=False
+        is_gradient=False,
+        execution_mode=execution_mode,
     )
 
     k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest = _compute_all_kernel_terms(
@@ -89,7 +100,7 @@ def create_scalar_kernel(ki: KernelInput, options: KernelOptions) -> tensor_type
             drift_start_post_y=j_size
         )
 
-        if BackendTensor.pykeops_enabled:
+        if execution_mode is KernelExecutionMode.PYKEOPS:
             selector_components = selector_components.upgrade_tensors()
 
         selector = bt.t.sum(selector_components.sel_ui * (selector_components.sel_vj + 1), axis=-1)
@@ -102,13 +113,22 @@ def create_scalar_kernel(ki: KernelInput, options: KernelOptions) -> tensor_type
 
 
 # noinspection DuplicatedCode
-def create_grad_kernel(ki: KernelInput, options: KernelOptions) -> tensor_types:
+def create_grad_kernel(
+        ki: KernelInput,
+        options: KernelOptions,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> tensor_types:
     kernel_f = options.kernel_function.value
     a = options.range
     c_o = options.c_o
 
-    dm = _compute_all_distance_matrices(ki.cartesian_selector, ki.ori_sp_matrices,
-                                        square_distance=kernel_f.consume_sq_distance, is_gradient=True)
+    dm = _compute_all_distance_matrices(
+        ki.cartesian_selector,
+        ki.ori_sp_matrices,
+        square_distance=kernel_f.consume_sq_distance,
+        is_gradient=True,
+        execution_mode=execution_mode,
+    )
 
     k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest = \
         _compute_all_kernel_terms(a, kernel_f, dm.r_ref_ref, dm.r_ref_rest, dm.r_rest_ref, dm.r_rest_rest)
@@ -147,87 +167,19 @@ def _compute_all_kernel_terms(range_: int, kernel_functions: KernelFunction, r_r
     return k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest
 
 
-class DistancesBuffer:
-    last_internal_distances_matrices: InternalDistancesMatrices = None
-
-
 # noinspection DuplicatedCode
 def _compute_all_distance_matrices(cs: CartesianSelector, ori_sp_matrices: OrientationSurfacePointsCoords,
-                                   square_distance: bool, is_gradient: bool, is_testing: bool = False) -> InternalDistancesMatrices:
-    # ! For the DistanceBuffer optimization we are assuming that we are always computing the scalar kernel first
-    # ! and then the gradient kernel. This is because the gradient kernel needs the scalar kernel distances
-
-    is_cached_matrices = DistancesBuffer.last_internal_distances_matrices is not None
-    if is_gradient and is_cached_matrices and is_testing is False:
-        # Check if the cached matrices have the same ni as the current cartesian selector
-        # If we are stacking scalar and gradients, the ni of the stacked cartesian selector will be larger
-        if DistancesBuffer.last_internal_distances_matrices.dif_ref_ref.shape[0] == cs.hu_sel_i.shape[0]:
-            distance_matrices: InternalDistancesMatrices = _compute_distances_using_cache(
-                cs=cs,
-                last_internal_distances_matrices=DistancesBuffer.last_internal_distances_matrices
-            )
-        else:
-            distance_matrices: InternalDistancesMatrices = _compute_distances_generic(cs, ori_sp_matrices, square_distance)
-    else:
-        distance_matrices: InternalDistancesMatrices = _compute_distances_generic(cs, ori_sp_matrices, square_distance)
-
-    if develeping_distances_buffer := False and is_gradient:  # This is for developing
-        _check_which_items_are_the_same_between_calls(distance_matrices)
-
-    DistancesBuffer.last_internal_distances_matrices = distance_matrices  # * Save common values for next call
-    return distance_matrices
+                                   square_distance: bool, is_gradient: bool, is_testing: bool = False,
+                                   execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE) -> InternalDistancesMatrices:
+    return _compute_distances_generic(cs, ori_sp_matrices, square_distance, execution_mode)
 
 
-def _compute_distances_using_cache(cs, last_internal_distances_matrices: InternalDistancesMatrices) -> InternalDistancesMatrices:
-    dif_ref_ref = last_internal_distances_matrices.dif_ref_ref  # Can be cached
-    dif_rest_rest = last_internal_distances_matrices.dif_rest_rest  # Can be cached
-
-    hu = last_internal_distances_matrices.hu  # Can be cached
-    hv = -bt.t.sum(dif_ref_ref * (cs.hv_sel_i * cs.hv_sel_j), axis=-1)  # Axis dependent
-
-    hu_ref = last_internal_distances_matrices.hu_ref  # Can be cached
-    hv_ref = bt.t.sum(dif_ref_ref * (cs.h_sel_ref_i * cs.hv_sel_j), axis=-1)  # Axis dependent
-    huv_ref = hu_ref - hv_ref  # Axis dependent
-
-    hu_rest = last_internal_distances_matrices.hu_rest  # Can be cached
-    hv_rest = bt.t.sum(dif_rest_rest * (cs.h_sel_rest_i * cs.hv_sel_j), axis=-1)  # Axis dependent
-    huv_rest = hu_rest - hv_rest  # Axis dependent
-
-    perp_matrix = bt.t.sum(cs.hu_sel_i * cs.hv_sel_j, axis=-1, dtype="int8")  # Axis dependent
-
-    # region: distance r
-    r_ref_ref = last_internal_distances_matrices.r_ref_ref  # Can be cached
-    r_rest_rest = last_internal_distances_matrices.r_rest_rest  # Can be cached
-    r_ref_rest = last_internal_distances_matrices.r_ref_rest  # Can be cached
-    r_rest_ref = last_internal_distances_matrices.r_rest_ref  # Can be cached
-
-    # region: For gradients
-    hu_ref_grad = bt.t.sum(dif_ref_ref * (cs.h_sel_ref_i * cs.hu_sel_j), axis=-1)  # Axis dependent
-    hu_rest_grad = bt.t.sum(dif_rest_rest * (cs.h_sel_ref_i * cs.hu_sel_j), axis=-1)  # Axis dependent
-    # endregion
-
-    new_distance_matrices = InternalDistancesMatrices(
-        dif_ref_ref=dif_ref_ref,
-        dif_rest_rest=dif_rest_rest,
-        hu=hu,
-        hv=hv,
-        huv_ref=huv_ref,
-        huv_rest=huv_rest,
-        perp_matrix=perp_matrix,
-        r_ref_ref=r_ref_ref,
-        r_ref_rest=r_ref_rest,
-        r_rest_ref=r_rest_ref,
-        r_rest_rest=r_rest_rest,
-        hu_ref=hu_ref,
-        hu_rest=hu_rest,
-        hu_ref_grad=hu_ref_grad,
-        hu_rest_grad=hu_rest_grad,
-    )
-
-    return new_distance_matrices
-
-
-def _compute_distances_generic(cs: CartesianSelector, ori_sp_matrices, square_distance) -> InternalDistancesMatrices:
+def _compute_distances_generic(
+        cs: CartesianSelector,
+        ori_sp_matrices,
+        square_distance,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> InternalDistancesMatrices:
     dif_ref_ref = ori_sp_matrices.dip_ref_i - ori_sp_matrices.dip_ref_j  # Can be cached
     dif_rest_rest = ori_sp_matrices.diprest_i - ori_sp_matrices.diprest_j  # Can be cached
 
@@ -253,10 +205,16 @@ def _compute_distances_generic(cs: CartesianSelector, ori_sp_matrices, square_di
     if square_distance is False:
         # @off
         epsilon = 1e-10  # Add small regularization term to avoid numerical errors
-        r_ref_ref = bt.t.sqrt(r_ref_ref + epsilon)
-        r_rest_rest = bt.t.sqrt(r_rest_rest + epsilon)
-        r_ref_rest = bt.t.sqrt(r_ref_rest + epsilon)
-        r_rest_ref = bt.t.sqrt(r_rest_ref + epsilon)
+        if execution_mode is KernelExecutionMode.PYKEOPS:
+            r_ref_ref = (r_ref_ref + epsilon).sqrt()
+            r_rest_rest = (r_rest_rest + epsilon).sqrt()
+            r_ref_rest = (r_ref_rest + epsilon).sqrt()
+            r_rest_ref = (r_rest_ref + epsilon).sqrt()
+        else:
+            r_ref_ref = bt.t.sqrt(r_ref_ref + epsilon)
+            r_rest_rest = bt.t.sqrt(r_rest_rest + epsilon)
+            r_ref_rest = bt.t.sqrt(r_ref_rest + epsilon)
+            r_rest_ref = bt.t.sqrt(r_rest_ref + epsilon)
     # endregion
 
     hu_ref_grad = bt.t.sum(dif_ref_ref * (cs.h_sel_ref_i * cs.hu_sel_j), axis=-1)  # Axis dependent
@@ -280,11 +238,3 @@ def _compute_distances_generic(cs: CartesianSelector, ori_sp_matrices, square_di
         hu_rest_grad=hu_rest_grad,
     )
     return new_distance_matrices
-
-
-def _check_which_items_are_the_same_between_calls(distance_matrices):
-    import numpy as np
-    print(f"Checking distances matrices. Shape: {distance_matrices.dif_ref_ref.shape}")
-    for k, v in DistancesBuffer.last_internal_distances_matrices.__dict__.items():
-        if not np.allclose(v, distance_matrices.__dict__[k]):
-            print("Not allclose", k)

--- a/gempy_engine/modules/kernel_constructor/_test_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_test_assembler.py
@@ -4,9 +4,15 @@ from gempy_engine.core.data.options import KernelOptions
 from gempy_engine.modules.kernel_constructor._covariance_assembler import _get_cov_grad, _get_cov_surface_points, _get_cross_cov_grad_sp, _get_universal_gradient_terms, _get_universal_sp_terms, get_covariance
 from gempy_engine.modules.kernel_constructor._kernels_assembler import _compute_all_distance_matrices, _compute_all_kernel_terms
 from gempy_engine.modules.kernel_constructor._structs import KernelInput
+from gempy_engine.modules.kernel_constructor.execution_mode import KernelExecutionMode
 
 
-def _test_covariance_items(ki: KernelInput, options: KernelOptions, item):
+def _test_covariance_items(
+        ki: KernelInput,
+        options: KernelOptions,
+        item,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+):
     """This method is not to be executed in production. Just for sanity check
     """
     # Deprecation warning
@@ -21,18 +27,29 @@ def _test_covariance_items(ki: KernelInput, options: KernelOptions, item):
         ori_sp_matrices=ki.ori_sp_matrices,
         square_distance=True,
         is_gradient=True,
-        is_testing=True
+        is_testing=True,
+        execution_mode=execution_mode,
     )
 
     k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest = \
         _compute_all_kernel_terms(a, kernel_f, dm.r_ref_ref, dm.r_ref_rest, dm.r_rest_ref, dm.r_rest_rest)
 
     if item == "cov_grad":
-        cov_grad = _get_cov_grad(dm, k_a, k_p_ref, ki.nugget_grad)
+        cov_grad = _get_cov_grad(dm, k_a, k_p_ref, ki.nugget_grad, execution_mode)
         return cov_grad
 
     elif item == "cov_sp":
-        return _get_cov_surface_points(k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest, options)
+        return _get_cov_surface_points(
+            dm,
+            k_ref_ref,
+            k_ref_rest,
+            k_rest_ref,
+            k_rest_rest,
+            options,
+            ki.nugget_scalar,
+            ki.nugget_grad.shape[1],
+            execution_mode,
+        )
 
     elif item == "cov_grad_sp":
         cov_grad_sp = _get_cross_cov_grad_sp(dm, k_p_ref, k_p_rest, options)
@@ -63,7 +80,20 @@ def _test_covariance_items(ki: KernelInput, options: KernelOptions, item):
 
     elif item == "cov":
 
-        cov = get_covariance(c_o, dm, k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest, ki, options)
+        cov = get_covariance(
+            c_o,
+            dm,
+            k_a,
+            k_p_ref,
+            k_p_rest,
+            k_ref_ref,
+            k_ref_rest,
+            k_rest_ref,
+            k_rest_rest,
+            ki,
+            options,
+            execution_mode,
+        )
         return cov
 
     elif item == "sigma_0_sp":

--- a/gempy_engine/modules/kernel_constructor/execution_mode.py
+++ b/gempy_engine/modules/kernel_constructor/execution_mode.py
@@ -3,4 +3,4 @@ from enum import Enum, auto
 
 class KernelExecutionMode(Enum):
     DENSE = auto()
-    PYKEOPS = auto()
+    SYMBOLIC = auto()

--- a/gempy_engine/modules/kernel_constructor/execution_mode.py
+++ b/gempy_engine/modules/kernel_constructor/execution_mode.py
@@ -1,0 +1,6 @@
+from enum import Enum, auto
+
+
+class KernelExecutionMode(Enum):
+    DENSE = auto()
+    PYKEOPS = auto()

--- a/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
+++ b/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
@@ -29,12 +29,12 @@ def yield_evaluation_kernel(interp_input: SolverInput, kernel_options: KernelOpt
     
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis=None, slice_array=slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
-    execution_mode = KernelExecutionMode.PYKEOPS if pykeops else KernelExecutionMode.DENSE
+    execution_mode = KernelExecutionMode.SYMBOLIC if pykeops else KernelExecutionMode.DENSE
     return create_scalar_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
 
 
 def yield_evaluation_grad_kernel(interp_input: SolverInput, kernel_options: KernelOptions, axis: int = 0, slice_array = None, pykeops: bool = False):
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis, slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
-    execution_mode = KernelExecutionMode.PYKEOPS if pykeops else KernelExecutionMode.DENSE
+    execution_mode = KernelExecutionMode.SYMBOLIC if pykeops else KernelExecutionMode.DENSE
     return create_grad_kernel(kernel_data, kernel_options, execution_mode=execution_mode)

--- a/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
+++ b/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
@@ -5,14 +5,19 @@ from ...core.data.kernel_classes.orientations import OrientationsInternals
 from ._b_vector_assembler import b_vector_assembly
 from ._kernels_assembler import create_cov_kernel, create_scalar_kernel, create_grad_kernel
 from ._vectors_preparation import cov_vectors_preparation, evaluation_vectors_preparations
+from .execution_mode import KernelExecutionMode
 from ...core.data.options import KernelOptions
 
 tensor_types = BackendTensor.tensor_types
 
 
-def yield_covariance(interp_input: SolverInput, kernel_options: KernelOptions) -> tensor_types:
+def yield_covariance(
+        interp_input: SolverInput,
+        kernel_options: KernelOptions,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> tensor_types:
     kernel_data = cov_vectors_preparation(interp_input, kernel_options)
-    cov = create_cov_kernel(kernel_data, kernel_options)
+    cov = create_cov_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
     return cov
 
 
@@ -24,10 +29,12 @@ def yield_evaluation_kernel(interp_input: SolverInput, kernel_options: KernelOpt
     
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis=None, slice_array=slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
-    return create_scalar_kernel(kernel_data, kernel_options)
+    execution_mode = KernelExecutionMode.PYKEOPS if pykeops else KernelExecutionMode.DENSE
+    return create_scalar_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
 
 
 def yield_evaluation_grad_kernel(interp_input: SolverInput, kernel_options: KernelOptions, axis: int = 0, slice_array = None, pykeops: bool = False):
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis, slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
-    return create_grad_kernel(kernel_data, kernel_options)
+    execution_mode = KernelExecutionMode.PYKEOPS if pykeops else KernelExecutionMode.DENSE
+    return create_grad_kernel(kernel_data, kernel_options, execution_mode=execution_mode)

--- a/gempy_engine/modules/solver/_numpy_solvers.py
+++ b/gempy_engine/modules/solver/_numpy_solvers.py
@@ -3,8 +3,6 @@ import numpy as np
 from gempy_engine import optional_dependencies
 from gempy_engine.core.backend_tensor import BackendTensor
 
-bt = BackendTensor
-
 
 def pykeops_numpy_cg(b, cov, dtype):
     # ! Only Positive definite matrices are solved. Otherwise, the kernel gets stuck
@@ -25,9 +23,6 @@ def numpy_solve(b, cov, dtype):
 
 
 def numpy_cg(b, cov):
-    if bt.use_gpu is False and BackendTensor.pykeops_enabled is True:
-        cov.backend = 'CPU'
-
     from ._pykeops_solvers.incomplete_cholesky import ichol
     from ._pykeops_solvers.cg import cg
     

--- a/gempy_engine/modules/solver/fault_drift_stabilization.py
+++ b/gempy_engine/modules/solver/fault_drift_stabilization.py
@@ -23,9 +23,6 @@ def stabilize_fault_drift_system(
         raise ValueError("n_faults must be between zero and the matrix size")
     if not math.isfinite(relative_regularization) or relative_regularization < 0:
         raise ValueError("relative_regularization must be finite and non-negative")
-    if BackendTensor.pykeops_enabled:
-        raise ValueError("Fault drift stabilization requires a dense covariance matrix")
-
     matrix_size = covariance.shape[0]
     fault_start = matrix_size - n_faults
     factors = BackendTensor.t.ones(matrix_size, dtype=covariance.dtype)

--- a/gempy_engine/modules/solver/interpolation_solver.py
+++ b/gempy_engine/modules/solver/interpolation_solver.py
@@ -168,14 +168,14 @@ def solve_pykeops_with_dense_fallback(interp_input, kernel_options: KernelOption
             lazy_kernel_data,
             interp_input,
             kernel_options,
-            KernelExecutionMode.PYKEOPS,
+            KernelExecutionMode.SYMBOLIC,
         )
         result = _solve_system(
             lazy_system,
             interp_input,
             kernel_options,
             InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK,
-            KernelExecutionMode.PYKEOPS,
+            KernelExecutionMode.SYMBOLIC,
         )
     except Exception as error:
         warnings.warn(
@@ -286,7 +286,7 @@ def _record_condition_numbers(
         system: InterpolationSystem,
         execution_mode: KernelExecutionMode,
 ) -> None:
-    if not kernel_options.compute_condition_number or execution_mode is KernelExecutionMode.PYKEOPS:
+    if not kernel_options.compute_condition_number or execution_mode is KernelExecutionMode.SYMBOLIC:
         return
     before = BackendTensor.t.linalg.cond(system.physical_matrix)
     after = BackendTensor.t.linalg.cond(system.solve_matrix)

--- a/gempy_engine/modules/solver/interpolation_solver.py
+++ b/gempy_engine/modules/solver/interpolation_solver.py
@@ -1,0 +1,316 @@
+import os
+import warnings
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from gempy_engine.config import AvailableBackends
+from gempy_engine.core.backend_tensor import BackendTensor
+from gempy_engine.core.data.continue_epoch import ContinueEpoch
+from gempy_engine.core.data.options import KernelOptions
+from gempy_engine.modules.kernel_constructor import kernel_constructor_interface as kernel_constructor
+from gempy_engine.modules.kernel_constructor._kernels_assembler import create_cov_kernel
+from gempy_engine.modules.kernel_constructor._structs import KernelInput
+from gempy_engine.modules.kernel_constructor._vectors_preparation import cov_vectors_preparation
+from gempy_engine.modules.kernel_constructor.execution_mode import KernelExecutionMode
+from gempy_engine.modules.solver import solver_interface
+from gempy_engine.modules.solver.fault_drift_stabilization import stabilize_fault_drift_system
+from gempy_engine.modules.solver.linear_system_transform import (
+    LinearSystemTransform,
+    add_fault_regularization,
+    equilibrate_symmetric_system,
+    normalized_residual,
+)
+
+
+class InterpolationSolveRoute(Enum):
+    DENSE_UNTRANSFORMED = auto()
+    DENSE_FAULT_STABILIZED = auto()
+    DENSE_RUIZ = auto()
+    PYKEOPS_WITH_DENSE_FALLBACK = auto()
+
+
+@dataclass(frozen=True)
+class InterpolationSystem:
+    physical_matrix: object
+    physical_rhs: object
+    transform: LinearSystemTransform | None = None
+
+    @property
+    def solve_matrix(self):
+        return self.transform.matrix if self.transform is not None else self.physical_matrix
+
+    @property
+    def solve_rhs(self):
+        return self.transform.rhs if self.transform is not None else self.physical_rhs
+
+    def scale_initial_guess(self, initial_guess):
+        return self.transform.scale_initial_guess(initial_guess) if self.transform is not None else initial_guess
+
+    def restore_weights(self, solver_weights):
+        return self.transform.restore_weights(solver_weights) if self.transform is not None else solver_weights
+
+
+@dataclass(frozen=True)
+class InterpolationSolveResult:
+    route: InterpolationSolveRoute
+    execution_mode: KernelExecutionMode
+    system: InterpolationSystem
+    solver_weights: object
+    weights: object
+    normalized_residual: float | None
+    used_fallback: bool = False
+
+
+def pykeops_solver_requested() -> bool:
+    return os.getenv("PYKEOPS_SOLVER", "False") == "True"
+
+
+def select_interpolation_solve_route(
+        kernel_options: KernelOptions,
+        n_faults: int,
+        pykeops_requested: bool,
+) -> InterpolationSolveRoute:
+    method = kernel_options.symmetric_equilibration_method
+    match (method, n_faults > 0, pykeops_requested, kernel_options.optimizing_condition_number):
+        case ("ruiz", _, True, _):
+            _warn_dense_route("symmetric equilibration")
+            return InterpolationSolveRoute.DENSE_RUIZ
+        case ("ruiz", _, False, _):
+            return InterpolationSolveRoute.DENSE_RUIZ
+        case ("none", True, True, _):
+            _warn_dense_route("fault stabilization")
+            return InterpolationSolveRoute.DENSE_FAULT_STABILIZED
+        case ("none", True, False, _):
+            return InterpolationSolveRoute.DENSE_FAULT_STABILIZED
+        case ("none", False, True, True):
+            _warn_dense_route("condition-number optimization")
+            return InterpolationSolveRoute.DENSE_UNTRANSFORMED
+        case ("none", False, True, False):
+            if BackendTensor.engine_backend is not AvailableBackends.PYTORCH:
+                raise ValueError("The PyKeOps solver requires the PyTorch backend")
+            return InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK
+        case ("none", False, False, _):
+            return InterpolationSolveRoute.DENSE_UNTRANSFORMED
+        case _:
+            raise ValueError(f"Unsupported symmetric equilibration method: {method!r}")
+
+
+def solve_dense_untransformed(
+        interp_input,
+        kernel_options: KernelOptions,
+        *,
+        kernel_data: KernelInput | None = None,
+        used_fallback: bool = False,
+) -> InterpolationSolveResult:
+    kernel_data = kernel_data or cov_vectors_preparation(interp_input, kernel_options)
+    system = _build_physical_system(kernel_data, interp_input, kernel_options, KernelExecutionMode.DENSE)
+    return _solve_or_raise(
+        system,
+        interp_input,
+        kernel_options,
+        InterpolationSolveRoute.DENSE_UNTRANSFORMED,
+        KernelExecutionMode.DENSE,
+        used_fallback,
+    )
+
+
+def solve_dense_fault_stabilized(interp_input, kernel_options: KernelOptions) -> InterpolationSolveResult:
+    n_faults = interp_input.fault_internal.n_faults
+    kernel_data = cov_vectors_preparation(interp_input, kernel_options)
+    physical_system = _build_physical_system(kernel_data, interp_input, kernel_options, KernelExecutionMode.DENSE)
+    transform = stabilize_fault_drift_system(
+        covariance=physical_system.physical_matrix,
+        b_vector=physical_system.physical_rhs,
+        n_faults=n_faults,
+        relative_regularization=kernel_options.fault_drift_regularization,
+        equilibrate=kernel_options.fault_drift_equilibration,
+    )
+    system = InterpolationSystem(physical_system.physical_matrix, physical_system.physical_rhs, transform)
+    return _solve_or_raise(
+        system,
+        interp_input,
+        kernel_options,
+        InterpolationSolveRoute.DENSE_FAULT_STABILIZED,
+        KernelExecutionMode.DENSE,
+    )
+
+
+def solve_dense_ruiz(interp_input, kernel_options: KernelOptions) -> InterpolationSolveResult:
+    n_faults = interp_input.fault_internal.n_faults
+    kernel_data = cov_vectors_preparation(interp_input, kernel_options)
+    physical_system = _build_physical_system(kernel_data, interp_input, kernel_options, KernelExecutionMode.DENSE)
+    transform = equilibrate_symmetric_system(
+        physical_system.physical_matrix,
+        physical_system.physical_rhs,
+        max_iterations=kernel_options.symmetric_equilibration_max_iterations,
+        tolerance=kernel_options.symmetric_equilibration_tolerance,
+    )
+    transform = add_fault_regularization(
+        transform,
+        n_faults=n_faults,
+        regularization=kernel_options.fault_drift_regularization,
+    )
+    system = InterpolationSystem(physical_system.physical_matrix, physical_system.physical_rhs, transform)
+    return _solve_or_raise(
+        system,
+        interp_input,
+        kernel_options,
+        InterpolationSolveRoute.DENSE_RUIZ,
+        KernelExecutionMode.DENSE,
+    )
+
+
+def solve_pykeops_with_dense_fallback(interp_input, kernel_options: KernelOptions) -> InterpolationSolveResult:
+    tensor_kernel_data = cov_vectors_preparation(interp_input, kernel_options)
+    try:
+        lazy_kernel_data = tensor_kernel_data.upgrade_tensors()
+        lazy_system = _build_physical_system(
+            lazy_kernel_data,
+            interp_input,
+            kernel_options,
+            KernelExecutionMode.PYKEOPS,
+        )
+        result = _solve_system(
+            lazy_system,
+            interp_input,
+            kernel_options,
+            InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK,
+            KernelExecutionMode.PYKEOPS,
+        )
+    except Exception as error:
+        warnings.warn(
+            f"PyKeOps interpolation failed; retrying with a dense solve: {error}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        result = None
+    if result is not None:
+        return result
+    return solve_dense_untransformed(
+        interp_input,
+        kernel_options,
+        kernel_data=tensor_kernel_data,
+        used_fallback=True,
+    )
+
+
+def assemble_solve_debug(result: InterpolationSolveResult, kernel_options: KernelOptions) -> dict[str, object]:
+    transform = result.system.transform
+    return {
+        "weights": result.weights,
+        "A_matrix": result.system.physical_matrix,
+        "b_vector": result.system.physical_rhs,
+        "A_matrix_physical": result.system.physical_matrix,
+        "b_vector_physical": result.system.physical_rhs,
+        "A_matrix_scaled": result.system.solve_matrix,
+        "b_vector_scaled": result.system.solve_rhs,
+        "scaling_factors": transform.factors if transform is not None else None,
+        "weights_scaled": result.solver_weights,
+        "weights_physical": result.weights,
+        "condition_number_before": kernel_options.condition_number_before,
+        "condition_number_after": kernel_options.condition_number_after,
+        "normalized_residual": result.normalized_residual,
+        "equilibration_iterations": transform.iterations if transform is not None else 0,
+        "equilibration_converged": transform.converged if transform is not None else True,
+        "solve_route": result.route,
+        "used_fallback": result.used_fallback,
+    }
+
+
+def _build_physical_system(
+        kernel_data: KernelInput,
+        interp_input,
+        kernel_options: KernelOptions,
+        execution_mode: KernelExecutionMode,
+) -> InterpolationSystem:
+    matrix = create_cov_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
+    rhs = kernel_constructor.yield_b_vector(interp_input.ori_internal, matrix.shape[0])
+    return InterpolationSystem(physical_matrix=matrix, physical_rhs=rhs)
+
+
+def _solve_or_raise(
+        system: InterpolationSystem,
+        interp_input,
+        kernel_options: KernelOptions,
+        route: InterpolationSolveRoute,
+        execution_mode: KernelExecutionMode,
+        used_fallback: bool = False,
+) -> InterpolationSolveResult:
+    result = _solve_system(system, interp_input, kernel_options, route, execution_mode, used_fallback)
+    if result is None:
+        raise RuntimeError(f"Interpolation solve failed for route {route.name}")
+    return result
+
+
+def _solve_system(
+        system: InterpolationSystem,
+        interp_input,
+        kernel_options: KernelOptions,
+        route: InterpolationSolveRoute,
+        execution_mode: KernelExecutionMode,
+        used_fallback: bool = False,
+) -> InterpolationSolveResult | None:
+    if kernel_options.optimizing_condition_number:
+        _optimize_nuggets_against_condition_number(system.solve_matrix, interp_input, kernel_options)
+
+    solver_weights = solver_interface.kernel_reduction(
+        cov=system.solve_matrix,
+        b=system.solve_rhs,
+        kernel_options=kernel_options,
+        x0=system.scale_initial_guess(interp_input.weights_x0),
+        execution_mode=execution_mode,
+    )
+    if solver_weights is None:
+        return None
+
+    weights = system.restore_weights(solver_weights)
+    residual = (
+        normalized_residual(system.physical_matrix, system.physical_rhs, weights)
+        if execution_mode is KernelExecutionMode.DENSE
+        else None
+    )
+    _record_condition_numbers(kernel_options, system, execution_mode)
+    return InterpolationSolveResult(
+        route=route,
+        execution_mode=execution_mode,
+        system=system,
+        solver_weights=solver_weights,
+        weights=weights,
+        normalized_residual=residual,
+        used_fallback=used_fallback,
+    )
+
+
+def _record_condition_numbers(
+        kernel_options: KernelOptions,
+        system: InterpolationSystem,
+        execution_mode: KernelExecutionMode,
+) -> None:
+    if not kernel_options.compute_condition_number or execution_mode is KernelExecutionMode.PYKEOPS:
+        return
+    before = BackendTensor.t.linalg.cond(system.physical_matrix)
+    after = BackendTensor.t.linalg.cond(system.solve_matrix)
+    kernel_options.condition_number_before = before
+    kernel_options.condition_number_after = after
+    kernel_options.condition_number = after
+
+
+def _optimize_nuggets_against_condition_number(matrix, interp_input, kernel_options: KernelOptions) -> None:
+    import torch
+
+    cond_number = BackendTensor.t.linalg.cond(matrix)
+    nuggets = interp_input.sp_internal.nugget_effect_ref_rest
+    l1_reg = torch.norm(nuggets, 2) ** 2
+    loss = cond_number - 100_000_000 * l1_reg
+    loss.backward()
+    kernel_options.condition_number = cond_number
+    print(f"Condition number: {cond_number}.")
+    raise ContinueEpoch()
+
+
+def _warn_dense_route(reason: str) -> None:
+    warnings.warn(
+        f"PyKeOps was requested, but {reason} requires a dense interpolation solve.",
+        RuntimeWarning,
+        stacklevel=3,
+    )

--- a/gempy_engine/modules/solver/solver_interface.py
+++ b/gempy_engine/modules/solver/solver_interface.py
@@ -7,57 +7,37 @@ from gempy_engine.core.data.kernel_classes.solvers import Solvers
 from ._numpy_solvers import numpy_solve, numpy_cg, numpy_gmres
 from ._torch_solvers import torch_solve, pykeops_torch_cg
 from ...core.data.options import KernelOptions
+from ..kernel_constructor.execution_mode import KernelExecutionMode
 
 bt = BackendTensor
 
 
-def kernel_reduction(cov, b, kernel_options: KernelOptions, x0: Optional[np.ndarray] = None) -> np.ndarray:
+def kernel_reduction(
+        cov,
+        b,
+        kernel_options: KernelOptions,
+        x0: Optional[np.ndarray] = None,
+        execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+) -> np.ndarray:
 
     solver: Solvers = kernel_options.kernel_solver
     # ? Maybe we should always compute the conditional_number no matter the branch
     dtype = BackendTensor.dtype
-    match (BackendTensor.engine_backend, BackendTensor.pykeops_enabled, solver):
-        case (AvailableBackends.PYTORCH, False, _):
-            if kernel_options.compute_condition_number:
-                cond_number = BackendTensor.t.linalg.cond(cov)
-                kernel_options.condition_number = cond_number
-                print(f'Condition number: {cond_number}.')
+    match (BackendTensor.engine_backend, execution_mode, solver):
+        case (AvailableBackends.PYTORCH, KernelExecutionMode.DENSE, _):
             w = torch_solve(b, cov)
-        case (AvailableBackends.PYTORCH, True, _):
+        case (AvailableBackends.PYTORCH, KernelExecutionMode.PYKEOPS, _):
             if x0 is not None and len(x0) == 0:
                 x0 = None
             w = pykeops_torch_cg(b, cov, x0, bt.use_gpu)
-        case (AvailableBackends.numpy, False, Solvers.DEFAULT):
+        case (AvailableBackends.numpy, KernelExecutionMode.DENSE, Solvers.DEFAULT):
             w = numpy_solve(b, cov, dtype)
-            if kernel_options.compute_condition_number:
-                kernel_options.condition_number = _compute_conditional_number(cov)
-        case (AvailableBackends.numpy, False, Solvers.DEFAULT |Solvers.SCIPY_CG):
+        case (AvailableBackends.numpy, KernelExecutionMode.DENSE, Solvers.DEFAULT |Solvers.SCIPY_CG):
             w = numpy_cg(b, cov)
-        case (AvailableBackends.numpy, False, Solvers.GMRES):
+        case (AvailableBackends.numpy, KernelExecutionMode.DENSE, Solvers.GMRES):
             w = numpy_gmres(b, cov)
         case _:
             raise AttributeError(f'There is a weird combination of libraries? '
-                                 f'{BackendTensor.engine_backend}, {BackendTensor.pykeops_enabled}, {solver}')
+                                 f'{BackendTensor.engine_backend}, {execution_mode}, {solver}')
 
     return w
-
-
-
-
-def _compute_conditional_number(cov, plot=False):
-    cond_number = np.linalg.cond(cov)
-    print(f'Condition number: {cond_number}.')
-    if plot:
-        import matplotlib.pyplot as plt
-        eigvals = np.linalg.eigvals(cov)
-        # Plotting the histogram
-        plt.hist(eigvals, bins=50, color='blue', alpha=0.7, log=True)
-        plt.xlabel('Eigenvalue')
-        plt.ylabel('Frequency')
-        plt.title('Histogram of Eigenvalues')
-        plt.show()
-        
-    return cond_number
-
-
-

--- a/gempy_engine/modules/solver/solver_interface.py
+++ b/gempy_engine/modules/solver/solver_interface.py
@@ -26,7 +26,7 @@ def kernel_reduction(
     match (BackendTensor.engine_backend, execution_mode, solver):
         case (AvailableBackends.PYTORCH, KernelExecutionMode.DENSE, _):
             w = torch_solve(b, cov)
-        case (AvailableBackends.PYTORCH, KernelExecutionMode.PYKEOPS, _):
+        case (AvailableBackends.PYTORCH, KernelExecutionMode.SYMBOLIC, _):
             if x0 is not None and len(x0) == 0:
                 x0 = None
             w = pykeops_torch_cg(b, cov, x0, bt.use_gpu)

--- a/gempy_engine/modules/weights_cache/weight_cache_policy.py
+++ b/gempy_engine/modules/weights_cache/weight_cache_policy.py
@@ -1,0 +1,138 @@
+import hashlib
+import warnings
+from dataclasses import asdict, dataclass
+from enum import Enum, auto
+from typing import Any
+
+import numpy as np
+
+from gempy_engine.core.backend_tensor import BackendTensor
+from gempy_engine.core.data.options import InterpolationOptions, KernelOptions
+from gempy_engine.modules.weights_cache.weights_cache_interface import WeightCache, generate_cache_key
+
+
+class WeightCacheRoute(Enum):
+    CACHED = auto()
+    SOLVE = auto()
+    SOLVE_AND_STORE = auto()
+
+
+@dataclass(frozen=True)
+class WeightCacheDecision:
+    route: WeightCacheRoute
+    key: str
+    fingerprint: str | None = None
+    weights: Any | None = None
+    write_to_disk: bool = True
+
+
+def resolve_weight_cache(
+        options: InterpolationOptions,
+        stack_number: int,
+        pykeops_requested: bool,
+        solver_input,
+) -> WeightCacheDecision:
+    key = f"{options.cache_model_name}.{stack_number}"
+    cache_enabled = (
+        options.cache_mode in (InterpolationOptions.CacheMode.CACHE, InterpolationOptions.CacheMode.IN_MEMORY_CACHE)
+        and not BackendTensor.COMPUTE_GRADS
+    )
+
+    match options.cache_mode:
+        case InterpolationOptions.CacheMode.CLEAR_CACHE:
+            WeightCache.initialize_cache_dir()
+            return WeightCacheDecision(route=WeightCacheRoute.SOLVE, key=key)
+        case _ if not cache_enabled:
+            return WeightCacheDecision(route=WeightCacheRoute.SOLVE, key=key)
+        case InterpolationOptions.CacheMode.CACHE | InterpolationOptions.CacheMode.IN_MEMORY_CACHE:
+            return _resolve_enabled_cache(options, key, pykeops_requested, solver_input)
+        case InterpolationOptions.CacheMode.NO_CACHE:
+            return WeightCacheDecision(route=WeightCacheRoute.SOLVE, key=key)
+        case _:
+            raise ValueError("Cache mode not recognized")
+
+
+def store_weight_result(decision: WeightCacheDecision, weights) -> None:
+    if decision.route is not WeightCacheRoute.SOLVE_AND_STORE:
+        return
+    WeightCache.store_weights(
+        file_name=decision.key,
+        hash=decision.fingerprint,
+        weights=weights,
+        write_to_disk=decision.write_to_disk,
+    )
+
+
+def cacheable_kernel_options(kernel_options: KernelOptions) -> dict[str, object]:
+    parameters = asdict(kernel_options)
+    for runtime_field in ("condition_number", "condition_number_before", "condition_number_after"):
+        parameters.pop(runtime_field, None)
+    return parameters
+
+
+def solver_input_fingerprint(solver_input) -> str:
+    hasher = hashlib.sha256()
+    fields = (
+        ("surface_points_ref", solver_input.sp_internal.ref_surface_points),
+        ("surface_points_rest", solver_input.sp_internal.rest_surface_points),
+        ("surface_points_nugget", solver_input.sp_internal.nugget_effect_ref_rest),
+        ("orientation_positions", solver_input.ori_internal.dip_positions_tiled),
+        ("orientation_gradients", solver_input.ori_internal.gradients_tiled),
+        ("orientation_nugget", solver_input.ori_internal.nugget_effect_grad),
+        ("fault_values_ref", solver_input.fault_internal.fault_values_ref),
+        ("fault_values_rest", solver_input.fault_internal.fault_values_rest),
+    )
+    for name, values in fields:
+        hasher.update(name.encode())
+        if values is None:
+            hasher.update(b"none")
+            continue
+        array = np.ascontiguousarray(BackendTensor.t.to_numpy(values))
+        hasher.update(str(array.shape).encode())
+        hasher.update(str(array.dtype).encode())
+        hasher.update(array.tobytes())
+    return hasher.hexdigest()
+
+
+def _resolve_enabled_cache(
+        options: InterpolationOptions,
+        key: str,
+        pykeops_requested: bool,
+        solver_input,
+) -> WeightCacheDecision:
+    timestamp = options.temp_interpolation_values.start_computation_ts
+    if timestamp == -1:
+        warnings.warn("No start computation timestamp found. No caching.")
+        return WeightCacheDecision(route=WeightCacheRoute.SOLVE, key=key)
+
+    fingerprint = generate_cache_key(
+        name="",
+        parameters={
+            "schema": 2,
+            "ts": timestamp,
+            "kernel_options": cacheable_kernel_options(options.kernel_options),
+            "solver": repr(options.kernel_options.kernel_solver),
+            "backend": repr(BackendTensor.engine_backend),
+            "dtype": str(BackendTensor.dtype),
+            "pykeops": pykeops_requested,
+            "solver_input": solver_input_fingerprint(solver_input),
+        },
+    )
+    cached = WeightCache.load_weights(
+        key=key,
+        look_in_disk=options.cache_mode is not InterpolationOptions.CacheMode.IN_MEMORY_CACHE,
+    )
+    if cached is not None and cached["hash"] == fingerprint:
+        return WeightCacheDecision(
+            route=WeightCacheRoute.CACHED,
+            key=key,
+            fingerprint=fingerprint,
+            weights=cached["weights"],
+            write_to_disk=options.cache_mode is InterpolationOptions.CacheMode.CACHE,
+        )
+    return WeightCacheDecision(
+        route=WeightCacheRoute.SOLVE_AND_STORE,
+        key=key,
+        fingerprint=fingerprint,
+        write_to_disk=options.cache_mode is InterpolationOptions.CacheMode.CACHE,
+    )

--- a/gempy_engine/modules/weights_cache/weights_cache_interface.py
+++ b/gempy_engine/modules/weights_cache/weights_cache_interface.py
@@ -2,6 +2,7 @@
 import os
 import pickle
 import tempfile
+import threading
 from typing import Optional
 
 
@@ -17,23 +18,26 @@ class WeightCache:
 
     max_size_mb = 50
     reduce_to_mb = 25
+    _lock = threading.RLock()
 
     @staticmethod
     def initialize_cache_dir(disk_cache_dir=None):
-        if disk_cache_dir is None:
-            # Use a subdirectory in the system's temp directory
-            temp_dir = tempfile.gettempdir()
-            WeightCache.disk_cache_dir = os.path.join(temp_dir, "gempy_cache")
-        else:
-            WeightCache.disk_cache_dir = disk_cache_dir
+        with WeightCache._lock:
+            if disk_cache_dir is None:
+                # Use a subdirectory in the system's temp directory
+                temp_dir = tempfile.gettempdir()
+                WeightCache.disk_cache_dir = os.path.join(temp_dir, "gempy_cache")
+            else:
+                WeightCache.disk_cache_dir = disk_cache_dir
 
-        os.makedirs(WeightCache.disk_cache_dir, exist_ok=True)
-        WeightCache._check_and_cleanup_cache()
+            os.makedirs(WeightCache.disk_cache_dir, exist_ok=True)
+            WeightCache._check_and_cleanup_cache()
     
     @staticmethod
     def clear_cache():
-        WeightCache.memory_cache = {}
-        WeightCache._check_and_cleanup_cache()
+        with WeightCache._lock:
+            WeightCache.memory_cache = {}
+            WeightCache._check_and_cleanup_cache()
     
     @staticmethod
     def _check_and_cleanup_cache():
@@ -64,42 +68,45 @@ class WeightCache:
         return os.path.join(WeightCache.disk_cache_dir, f"{key}.pkl")
 
     @staticmethod
-    def store_weights(file_name, hash, weights):
-        
-        # Store in memory
-        WeightCache.memory_cache[file_name] = {
+    def store_weights(file_name, hash, weights, write_to_disk: bool = True):
+        cache_entry = {
             "hash": hash,
-            "weights": weights
+            "weights": weights,
         }
+        with WeightCache._lock:
+            WeightCache.memory_cache[file_name] = cache_entry
+            if not write_to_disk:
+                return
 
-        # Optionally store on disk as well
-        with open(WeightCache._disk_cache_path(file_name), 'wb') as f:
-            pickle.dump(
-                {
-                    "hash": hash,
-                    "weights": weights
-                },
-                f)
+            final_path = WeightCache._disk_cache_path(file_name)
+            file_descriptor, temporary_path = tempfile.mkstemp(
+                prefix=f"{file_name}.",
+                suffix=".tmp",
+                dir=WeightCache.disk_cache_dir,
+            )
+            try:
+                with os.fdopen(file_descriptor, "wb") as cache_file:
+                    pickle.dump(cache_entry, cache_file)
+                os.replace(temporary_path, final_path)
+            finally:
+                if os.path.exists(temporary_path):
+                    os.remove(temporary_path)
 
     @staticmethod
     def load_weights(key, look_in_disk: bool) -> Optional[dict]:
-        # Try to load from memory
-        if key in WeightCache.memory_cache:
-            return WeightCache.memory_cache[key]
+        with WeightCache._lock:
+            if key in WeightCache.memory_cache:
+                return WeightCache.memory_cache[key]
 
-        # Load from disk if not in memory
-        if not look_in_disk:
-            return None
-        disk_path = WeightCache._disk_cache_path(key)
-        if os.path.exists(disk_path):
-            with open(disk_path, 'rb') as f:
-                try:
-                    weights = pickle.load(f)
-                except ModuleNotFoundError:
-                    # Handle case where the module has been renamed
-                    # and the pickled object cannot be loaded
-                    return None
-                # Optionally cache in memory again
+            if not look_in_disk:
+                return None
+            disk_path = WeightCache._disk_cache_path(key)
+            if os.path.exists(disk_path):
+                with open(disk_path, "rb") as cache_file:
+                    try:
+                        weights = pickle.load(cache_file)
+                    except (ModuleNotFoundError, EOFError, pickle.UnpicklingError):
+                        return None
                 WeightCache.memory_cache[key] = weights
                 return weights
 

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
@@ -20,6 +20,7 @@ from gempy_engine.modules.kernel_constructor._structs import CartesianSelector
 from gempy_engine.modules.kernel_constructor._vectors_preparation import cov_vectors_preparation, \
     evaluation_vectors_preparations
 from gempy_engine.modules.kernel_constructor.kernel_constructor_interface import yield_covariance, yield_b_vector
+from gempy_engine.modules.kernel_constructor.execution_mode import KernelExecutionMode
 
 import pickle
 import os
@@ -187,7 +188,12 @@ class TestPykeopsNumPyEqual():
         BackendTensor._change_backend(AvailableBackends.numpy, use_pykeops=False)
         solver_input = SolverInput(sp_internals, ori_internals)
         kernel_data = cov_vectors_preparation(solver_input, options.kernel_options)
-        c_n = cov_func(kernel_data, options, item=item)
+        c_n = cov_func(
+            kernel_data,
+            options,
+            item=item,
+            execution_mode=KernelExecutionMode.DENSE,
+        )
 
         path = dir_name + f"/../solutions/{item}.npy"
         if False:
@@ -199,7 +205,12 @@ class TestPykeopsNumPyEqual():
         # pykeops
         BackendTensor._change_backend(AvailableBackends.numpy, use_pykeops=True)
         kernel_data = cov_vectors_preparation(solver_input, options.kernel_options)
-        c_k = cov_func(kernel_data, options, item=item)
+        c_k = cov_func(
+            kernel_data,
+            options,
+            item=item,
+            execution_mode=KernelExecutionMode.PYKEOPS,
+        )
         c_k_sum = c_n.sum(0).reshape(-1, 1)
 
         print('l: ', l)

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
@@ -209,7 +209,7 @@ class TestPykeopsNumPyEqual():
             kernel_data,
             options,
             item=item,
-            execution_mode=KernelExecutionMode.PYKEOPS,
+            execution_mode=KernelExecutionMode.SYMBOLIC,
         )
         c_k_sum = c_n.sum(0).reshape(-1, 1)
 

--- a/tests/test_common/test_modules/test_solvers/test_interpolation_solver_routing.py
+++ b/tests/test_common/test_modules/test_solvers/test_interpolation_solver_routing.py
@@ -1,0 +1,222 @@
+import concurrent.futures
+import threading
+from contextlib import nullcontext
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import gempy_engine.API.interp_single._interp_scalar_field as scalar_field_api
+import gempy_engine.modules.solver.interpolation_solver as interpolation_solver
+from gempy_engine.config import AvailableBackends, is_pykeops_installed
+from gempy_engine.core.backend_tensor import BackendTensor
+from gempy_engine.core.data.internal_structs import SolverInput
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
+from gempy_engine.core.data.options import KernelOptions
+from gempy_engine.modules.data_preprocess._input_preparation import orientations_preprocess, surface_points_preprocess
+from gempy_engine.modules.kernel_constructor.execution_mode import KernelExecutionMode
+from gempy_engine.modules.kernel_constructor.kernel_constructor_interface import yield_covariance
+from gempy_engine.modules.solver.interpolation_solver import (
+    InterpolationSolveRoute,
+    select_interpolation_solve_route,
+)
+
+
+@pytest.mark.parametrize(
+    ("method", "n_faults", "pykeops_requested", "optimizing", "expected"),
+    [
+        ("none", 0, False, False, InterpolationSolveRoute.DENSE_UNTRANSFORMED),
+        ("none", 1, False, False, InterpolationSolveRoute.DENSE_FAULT_STABILIZED),
+        ("ruiz", 0, False, False, InterpolationSolveRoute.DENSE_RUIZ),
+        ("ruiz", 2, False, False, InterpolationSolveRoute.DENSE_RUIZ),
+        ("none", 0, True, False, InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK),
+        ("none", 0, True, True, InterpolationSolveRoute.DENSE_UNTRANSFORMED),
+    ],
+)
+def test_select_interpolation_solve_route(
+        monkeypatch,
+        method,
+        n_faults,
+        pykeops_requested,
+        optimizing,
+        expected,
+):
+    monkeypatch.setattr(BackendTensor, "engine_backend", AvailableBackends.PYTORCH)
+    options = KernelOptions(
+        range=1,
+        c_o=1,
+        symmetric_equilibration_method=method,
+        optimizing_condition_number=optimizing,
+    )
+
+    warning_context = (
+        pytest.warns(RuntimeWarning)
+        if pykeops_requested and expected is not InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK
+        else nullcontext()
+    )
+    with warning_context:
+        route = select_interpolation_solve_route(options, n_faults, pykeops_requested)
+
+    assert route is expected
+
+
+def test_numpy_pykeops_route_is_rejected(monkeypatch):
+    monkeypatch.setattr(BackendTensor, "engine_backend", AvailableBackends.numpy)
+    options = KernelOptions(range=1, c_o=1)
+
+    with pytest.raises(ValueError, match="requires the PyTorch backend"):
+        select_interpolation_solve_route(options, n_faults=0, pykeops_requested=True)
+
+
+def test_concurrent_mixed_routes_do_not_mutate_global_pykeops_state(monkeypatch):
+    monkeypatch.setattr(BackendTensor, "engine_backend", AvailableBackends.PYTORCH)
+    monkeypatch.setattr(BackendTensor, "pykeops_enabled", False)
+    barrier = threading.Barrier(2)
+    observed_routes = []
+
+    def _result(route):
+        barrier.wait(timeout=5)
+        observed_routes.append((route, BackendTensor.pykeops_enabled))
+        return SimpleNamespace(weights=np.array([1.0]))
+
+    monkeypatch.setattr(
+        scalar_field_api,
+        "solve_dense_fault_stabilized",
+        lambda *_: _result(InterpolationSolveRoute.DENSE_FAULT_STABILIZED),
+    )
+    monkeypatch.setattr(
+        scalar_field_api,
+        "solve_pykeops_with_dense_fallback",
+        lambda *_: _result(InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK),
+    )
+
+    fault_input = SimpleNamespace(fault_internal=SimpleNamespace(n_faults=1))
+    no_fault_input = SimpleNamespace(fault_internal=SimpleNamespace(n_faults=0))
+    fault_options = KernelOptions(range=1, c_o=1)
+    no_fault_options = KernelOptions(range=1, c_o=1)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(scalar_field_api._solve_interpolation, fault_input, fault_options, True),
+            executor.submit(scalar_field_api._solve_interpolation, no_fault_input, no_fault_options, True),
+        ]
+        weights = [future.result(timeout=10) for future in futures]
+
+    assert all(np.array_equal(weight, np.array([1.0])) for weight in weights)
+    assert set(observed_routes) == {
+        (InterpolationSolveRoute.DENSE_FAULT_STABILIZED, False),
+        (InterpolationSolveRoute.PYKEOPS_WITH_DENSE_FALLBACK, False),
+    }
+    assert BackendTensor.pykeops_enabled is False
+
+
+def test_dense_covariance_mode_ignores_global_pykeops_flag(monkeypatch, simple_model_2):
+    surface_points, orientations, options, descriptor = simple_model_2
+    solver_input = SolverInput(
+        surface_points_preprocess(surface_points, descriptor.tensors_structure),
+        orientations_preprocess(orientations),
+    )
+    monkeypatch.setattr(BackendTensor, "pykeops_enabled", True)
+
+    covariance = yield_covariance(
+        solver_input,
+        options.kernel_options,
+        execution_mode=KernelExecutionMode.DENSE,
+    )
+
+    assert covariance.shape[0] == covariance.shape[1]
+    assert BackendTensor.pykeops_enabled is True
+
+
+@pytest.mark.skipif(not is_pykeops_installed, reason="PyKeOps is not installed")
+def test_actual_dense_fault_and_pykeops_solves_can_run_concurrently(monkeypatch, simple_model_2):
+    if BackendTensor.engine_backend is not AvailableBackends.PYTORCH:
+        pytest.skip("Mixed execution-mode solve requires the PyTorch test backend")
+
+    surface_points, orientations, options, descriptor = simple_model_2
+    sp_internal = surface_points_preprocess(surface_points, descriptor.tensors_structure)
+    ori_internal = orientations_preprocess(orientations)
+    no_fault_input = SolverInput(sp_internal, ori_internal)
+    n_surface_equations = sp_internal.n_points
+    fault_data = FaultsData(
+        fault_values_everywhere=BackendTensor.t.zeros((1, 0), dtype=BackendTensor.dtype_obj),
+        fault_values_on_sp=BackendTensor.t.zeros((1, surface_points.n_points), dtype=BackendTensor.dtype_obj),
+        fault_values_ref=BackendTensor.t.ones((1, n_surface_equations), dtype=BackendTensor.dtype_obj),
+        fault_values_rest=BackendTensor.t.zeros((1, n_surface_equations), dtype=BackendTensor.dtype_obj),
+    )
+    fault_input = SolverInput(sp_internal, ori_internal, fault_internal=fault_data)
+    monkeypatch.setattr(BackendTensor, "pykeops_enabled", False)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        dense_future = executor.submit(
+            scalar_field_api._solve_interpolation,
+            fault_input,
+            deepcopy(options.kernel_options),
+            True,
+        )
+        lazy_future = executor.submit(
+            scalar_field_api._solve_interpolation,
+            no_fault_input,
+            deepcopy(options.kernel_options),
+            True,
+        )
+        dense_weights = dense_future.result(timeout=60)
+        lazy_weights = lazy_future.result(timeout=60)
+
+    assert bool(BackendTensor.t.isfinite(dense_weights).all())
+    assert bool(BackendTensor.t.isfinite(lazy_weights).all())
+    assert BackendTensor.pykeops_enabled is False
+
+
+def test_pykeops_exception_falls_back_to_dense(monkeypatch):
+    kernel_data = SimpleNamespace(upgrade_tensors=lambda: object())
+    expected = SimpleNamespace(weights=np.array([2.0]), used_fallback=True)
+    monkeypatch.setattr(interpolation_solver, "cov_vectors_preparation", lambda *_: kernel_data)
+    monkeypatch.setattr(
+        interpolation_solver,
+        "_build_physical_system",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("lazy failure")),
+    )
+    fallback_calls = []
+
+    def _dense_fallback(*args, **kwargs):
+        fallback_calls.append(kwargs)
+        return expected
+
+    monkeypatch.setattr(interpolation_solver, "solve_dense_untransformed", _dense_fallback)
+
+    with pytest.warns(RuntimeWarning, match="retrying with a dense solve"):
+        result = interpolation_solver.solve_pykeops_with_dense_fallback(
+            SimpleNamespace(),
+            KernelOptions(range=1, c_o=1),
+        )
+
+    assert result is expected
+    assert fallback_calls == [{"kernel_data": kernel_data, "used_fallback": True}]
+
+
+def test_fallback_result_is_not_stored_in_pykeops_cache(monkeypatch):
+    weights = np.array([3.0])
+    decision = SimpleNamespace(
+        route=scalar_field_api.WeightCacheRoute.SOLVE_AND_STORE,
+        weights=None,
+    )
+    monkeypatch.setattr(scalar_field_api, "pykeops_solver_requested", lambda: True)
+    monkeypatch.setattr(scalar_field_api, "resolve_weight_cache", lambda **kwargs: decision)
+    monkeypatch.setattr(
+        scalar_field_api,
+        "_solve_interpolation_result",
+        lambda *args: SimpleNamespace(weights=weights, used_fallback=True),
+    )
+    stored = []
+    monkeypatch.setattr(scalar_field_api, "store_weight_result", lambda *args: stored.append(args))
+
+    actual = scalar_field_api.compute_weights(
+        SimpleNamespace(),
+        stack_number=0,
+        options=SimpleNamespace(kernel_options=KernelOptions(range=1, c_o=1)),
+    )
+
+    np.testing.assert_array_equal(actual, weights)
+    assert stored == []

--- a/tests/test_common/test_modules/test_weight_caching.py
+++ b/tests/test_common/test_modules/test_weight_caching.py
@@ -1,10 +1,39 @@
 ﻿import numpy as np
+from types import SimpleNamespace
 
-from gempy_engine.API.interp_single._interp_scalar_field import _cacheable_kernel_options
+from gempy_engine.core.data import InterpolationOptions
 from gempy_engine.core.data.options import KernelOptions
+from gempy_engine.modules.weights_cache.weight_cache_policy import (
+    WeightCacheRoute,
+    cacheable_kernel_options,
+    resolve_weight_cache,
+    store_weight_result,
+)
 from gempy_engine.modules.weights_cache.weights_cache_interface import (WeightCache, generate_cache_key)
 
 example_weights = np.array([.2, .2, .4, .2])
+
+
+class _CacheSolverInput:
+    def __init__(self, identity: int):
+        self.identity = identity
+        self.sp_internal = SimpleNamespace(
+            ref_surface_points=np.array([[identity, 0.0]]),
+            rest_surface_points=np.array([[0.0, identity]]),
+            nugget_effect_ref_rest=np.array([identity]),
+        )
+        self.ori_internal = SimpleNamespace(
+            dip_positions_tiled=np.array([[identity, 0.0]]),
+            gradients_tiled=np.array([[0.0, identity]]),
+            nugget_effect_grad=np.array([identity]),
+        )
+        self.fault_internal = SimpleNamespace(
+            fault_values_ref=np.array([[identity]]),
+            fault_values_rest=np.array([[0.0]]),
+        )
+
+    def __hash__(self):
+        return self.identity
 
 
 def test_save_weights():
@@ -39,11 +68,86 @@ def test_load_weights():
 
 def test_kernel_stabilization_options_change_cache_fingerprint():
     options = KernelOptions(range=1, c_o=1)
-    initial = generate_cache_key("", _cacheable_kernel_options(options))
+    initial = generate_cache_key("", cacheable_kernel_options(options))
 
     options.fault_drift_regularization = 2e-3
-    regularized = generate_cache_key("", _cacheable_kernel_options(options))
+    regularized = generate_cache_key("", cacheable_kernel_options(options))
     options.symmetric_equilibration_method = "ruiz"
-    equilibrated = generate_cache_key("", _cacheable_kernel_options(options))
+    equilibrated = generate_cache_key("", cacheable_kernel_options(options))
 
     assert len({initial, regularized, equilibrated}) == 3
+
+
+def test_no_cache_mode_routes_directly_to_solve():
+    options = InterpolationOptions.from_args(range=1, c_o=1)
+    options.cache_mode = InterpolationOptions.CacheMode.NO_CACHE
+
+    decision = resolve_weight_cache(
+        options,
+        stack_number=2,
+        pykeops_requested=False,
+        solver_input=_CacheSolverInput(1),
+    )
+
+    assert decision.route is WeightCacheRoute.SOLVE
+    assert decision.key == ".2"
+
+
+def test_matching_cache_fingerprint_returns_cached_weights(monkeypatch):
+    options = InterpolationOptions.from_args(range=1, c_o=1)
+    options.cache_mode = InterpolationOptions.CacheMode.IN_MEMORY_CACHE
+    options.temp_interpolation_values.start_computation_ts = 123
+    expected_weights = np.array([1.0, 2.0])
+
+    solver_input = _CacheSolverInput(1)
+    first_decision = resolve_weight_cache(
+        options,
+        stack_number=0,
+        pykeops_requested=False,
+        solver_input=solver_input,
+    )
+    assert first_decision.route is WeightCacheRoute.SOLVE_AND_STORE
+    monkeypatch.setattr(
+        WeightCache,
+        "load_weights",
+        lambda key, look_in_disk: {
+            "hash": first_decision.fingerprint,
+            "weights": expected_weights,
+        },
+    )
+
+    decision = resolve_weight_cache(
+        options,
+        stack_number=0,
+        pykeops_requested=False,
+        solver_input=solver_input,
+    )
+
+    assert decision.route is WeightCacheRoute.CACHED
+    np.testing.assert_array_equal(decision.weights, expected_weights)
+
+
+def test_solver_input_identity_changes_cache_fingerprint(monkeypatch):
+    options = InterpolationOptions.from_args(range=1, c_o=1)
+    options.cache_mode = InterpolationOptions.CacheMode.CACHE
+    options.temp_interpolation_values.start_computation_ts = 123
+    monkeypatch.setattr(WeightCache, "load_weights", lambda **kwargs: None)
+
+    first = resolve_weight_cache(options, 0, False, _CacheSolverInput(1))
+    second = resolve_weight_cache(options, 0, False, _CacheSolverInput(2))
+
+    assert first.fingerprint != second.fingerprint
+
+
+def test_in_memory_cache_does_not_write_to_disk(monkeypatch):
+    options = InterpolationOptions.from_args(range=1, c_o=1)
+    options.cache_mode = InterpolationOptions.CacheMode.IN_MEMORY_CACHE
+    options.temp_interpolation_values.start_computation_ts = 123
+    monkeypatch.setattr(WeightCache, "load_weights", lambda **kwargs: None)
+    decision = resolve_weight_cache(options, 0, False, _CacheSolverInput(1))
+    stored = []
+    monkeypatch.setattr(WeightCache, "store_weights", lambda **kwargs: stored.append(kwargs))
+
+    store_weight_result(decision, example_weights)
+
+    assert stored[0]["write_to_disk"] is False


### PR DESCRIPTION
Implements PyKeOps support for kernel execution with dense fallback handling. Introduces a flexible interpolation routing mechanism to select solve strategies based on configuration. Adds weight caching policies to improve solver performance by reusing computed weights. Includes extensive unit tests to validate interpolation routing, fault handling, PyKeOps integration, and caching behavior. Updates kernel handling logic to accommodate new execution modes.