### PR TITLE
[ENH] Cache distance matrices across gradient kernel evaluations via DistancesBuffer

### DIFF
--- a/gempy_engine/modules/evaluator/generic_evaluator.py
+++ b/gempy_engine/modules/evaluator/generic_evaluator.py
@@ -7,6 +7,7 @@ from gempy_engine.core.data import InterpolationOptions
 from gempy_engine.core.data.exported_fields import ExportedFields
 from gempy_engine.core.data.internal_structs import SolverInput
 from gempy_engine.modules.kernel_constructor.kernel_constructor_interface import yield_evaluation_grad_kernel, yield_evaluation_kernel
+from gempy_engine.modules.kernel_constructor._internalDistancesMatrices import DistancesBuffer
 
 
 def generic_evaluator(
@@ -74,8 +75,12 @@ def _eval_on(
     options: InterpolationOptions,
     slice_array: slice
 ):
+    distance_buffer = DistancesBuffer() if options.compute_scalar_gradient else None
     eval_kernel = yield_evaluation_kernel(
-        solver_input, options.kernel_options, slice_array=slice_array
+        solver_input,
+        options.kernel_options,
+        slice_array=slice_array,
+        distance_buffer=distance_buffer,
     )
     try:
         scalar_field = (eval_kernel.T @ weights).reshape(-1)
@@ -90,20 +95,32 @@ def _eval_on(
 
     if options.compute_scalar_gradient:
         eval_gx = yield_evaluation_grad_kernel(
-            solver_input, options.kernel_options, axis=0, slice_array=slice_array
+            solver_input,
+            options.kernel_options,
+            axis=0,
+            slice_array=slice_array,
+            distance_buffer=distance_buffer,
         )
         gx_field = (eval_gx.T @ weights).reshape(-1)  # Use BEFORE deleting
         del eval_gx  # Clean up immediately after use
         
         eval_gy = yield_evaluation_grad_kernel(
-            solver_input, options.kernel_options, axis=1, slice_array=slice_array
+            solver_input,
+            options.kernel_options,
+            axis=1,
+            slice_array=slice_array,
+            distance_buffer=distance_buffer,
         )
         gy_field = (eval_gy.T @ weights).reshape(-1)  # Use BEFORE deleting
         del eval_gy  # Clean up immediately after use
 
         if options.number_dimensions == 3:
             eval_gz = yield_evaluation_grad_kernel(
-                solver_input, options.kernel_options, axis=2, slice_array=slice_array
+                solver_input,
+                options.kernel_options,
+                axis=2,
+                slice_array=slice_array,
+                distance_buffer=distance_buffer,
             )
             gz_field = (eval_gz.T @ weights).reshape(-1)  # Use BEFORE deleting
             del eval_gz  # Clean up immediately after use

--- a/gempy_engine/modules/evaluator/symbolic_evaluator.py
+++ b/gempy_engine/modules/evaluator/symbolic_evaluator.py
@@ -12,6 +12,7 @@ from ...core.data.exported_fields import ExportedFields
 from ...core.data.internal_structs import SolverInput, EvaluatorInput
 from ..kernel_constructor.kernel_constructor_interface import yield_evaluation_grad_kernel, yield_evaluation_kernel
 from ..kernel_constructor.execution_mode import KernelExecutionMode
+from ..kernel_constructor._internalDistancesMatrices import DistancesBuffer
 
 
 def symbolic_evaluator(solver_input: SolverInput, weights: np.ndarray, options: InterpolationOptions):
@@ -21,7 +22,13 @@ def symbolic_evaluator(solver_input: SolverInput, weights: np.ndarray, options: 
     # ! We need to benchmark GPU vs CPU with more input
     backend_string = "GPU" if BackendTensor.use_gpu else "CPU"
 
-    eval_kernel = yield_evaluation_kernel(solver_input, options.kernel_options, pykeops=True)
+    distance_buffer = DistancesBuffer() if options.compute_scalar_gradient else None
+    eval_kernel = yield_evaluation_kernel(
+        solver_input,
+        options.kernel_options,
+        pykeops=True,
+        distance_buffer=distance_buffer,
+    )
     if BackendTensor.engine_backend == gempy_engine.config.AvailableBackends.numpy:
         from pykeops.numpy import LazyTensor
         # Create lazy_weights with correct dimensions: we want (16, 1) to match eval_kernel's nj dimension
@@ -38,14 +45,32 @@ def symbolic_evaluator(solver_input: SolverInput, weights: np.ndarray, options: 
     gz_field: Optional[np.ndarray] = None
 
     if options.compute_scalar_gradient is True:
-        eval_gx_kernel = yield_evaluation_grad_kernel(solver_input, options.kernel_options, axis=0, pykeops=True)
-        eval_gy_kernel = yield_evaluation_grad_kernel(solver_input, options.kernel_options, axis=1, pykeops=True)
+        eval_gx_kernel = yield_evaluation_grad_kernel(
+            solver_input,
+            options.kernel_options,
+            axis=0,
+            pykeops=True,
+            distance_buffer=distance_buffer,
+        )
+        eval_gy_kernel = yield_evaluation_grad_kernel(
+            solver_input,
+            options.kernel_options,
+            axis=1,
+            pykeops=True,
+            distance_buffer=distance_buffer,
+        )
 
         gx_field = (eval_gx_kernel * lazy_weights).sum(axis=0, backend=backend_string).reshape(-1)
         gy_field = (eval_gy_kernel * lazy_weights).sum(axis=0, backend=backend_string).reshape(-1)
 
         if options.number_dimensions == 3:
-            eval_gz_kernel = yield_evaluation_grad_kernel(solver_input, options.kernel_options, axis=2, pykeops=True)
+            eval_gz_kernel = yield_evaluation_grad_kernel(
+                solver_input,
+                options.kernel_options,
+                axis=2,
+                pykeops=True,
+                distance_buffer=distance_buffer,
+            )
             gz_field = (eval_gz_kernel * lazy_weights).sum(axis=0, backend=backend_string).reshape(-1)
         elif options.number_dimensions == 2:
             gz_field = None

--- a/gempy_engine/modules/kernel_constructor/_internalDistancesMatrices.py
+++ b/gempy_engine/modules/kernel_constructor/_internalDistancesMatrices.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ...core.backend_tensor import BackendTensor
 from gempy_engine.config import DEBUG_MODE, AvailableBackends
+from .execution_mode import KernelExecutionMode
 
 
 @dataclass
@@ -43,4 +44,69 @@ class InternalDistancesMatrices:
             assert self.r_rest_rest.dtype == BackendTensor.dtype, f"Wrong dtype for r_rest_rest: {self.r_rest_rest.dtype}. should be {BackendTensor.dtype}"
             assert self.hu_ref.dtype == BackendTensor.dtype, f"Wrong dtype for hu_ref: {self.hu_ref.dtype}. should be {BackendTensor.dtype}"
             assert self.hu_rest.dtype == BackendTensor.dtype, f"Wrong dtype for hu_rest: {self.hu_rest.dtype}. should be {BackendTensor.dtype}"
+
+
+@dataclass(frozen=True)
+class SharedDistanceMatrices:
+    dif_ref_ref: object
+    dif_rest_rest: object
+    hu: object
+    r_ref_ref: object
+    r_ref_rest: object
+    r_rest_ref: object
+    r_rest_rest: object
+    hu_ref: object
+    hu_rest: object
+
+    @classmethod
+    def from_distance_matrices(cls, matrices: InternalDistancesMatrices) -> "SharedDistanceMatrices":
+        return cls(
+            dif_ref_ref=matrices.dif_ref_ref,
+            dif_rest_rest=matrices.dif_rest_rest,
+            hu=matrices.hu,
+            r_ref_ref=matrices.r_ref_ref,
+            r_ref_rest=matrices.r_ref_rest,
+            r_rest_ref=matrices.r_rest_ref,
+            r_rest_rest=matrices.r_rest_rest,
+            hu_ref=matrices.hu_ref,
+            hu_rest=matrices.hu_rest,
+        )
+
+
+@dataclass
+class DistancesBuffer:
+    shared: Optional[SharedDistanceMatrices] = None
+    cache_key: object = None
+    square_distance: Optional[bool] = None
+    execution_mode: Optional[KernelExecutionMode] = None
+    matrix_shape: Optional[tuple[int, ...]] = None
+
+    def store(
+            self,
+            matrices: InternalDistancesMatrices,
+            cache_key: object,
+            matrix_shape: tuple[int, ...],
+            square_distance: bool,
+            execution_mode: KernelExecutionMode,
+    ) -> None:
+        self.shared = SharedDistanceMatrices.from_distance_matrices(matrices)
+        self.cache_key = cache_key
+        self.square_distance = square_distance
+        self.execution_mode = execution_mode
+        self.matrix_shape = matrix_shape
+
+    def matches(
+            self,
+            cache_key: object,
+            matrix_shape: tuple[int, ...],
+            square_distance: bool,
+            execution_mode: KernelExecutionMode,
+    ) -> bool:
+        return (
+            self.shared is not None
+            and self.cache_key == cache_key
+            and self.matrix_shape == matrix_shape
+            and self.square_distance is square_distance
+            and self.execution_mode is execution_mode
+        )
             

--- a/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
+++ b/gempy_engine/modules/kernel_constructor/_kernels_assembler.py
@@ -1,6 +1,6 @@
 from . import _structs
 from ._covariance_assembler import get_covariance
-from ._internalDistancesMatrices import InternalDistancesMatrices
+from ._internalDistancesMatrices import DistancesBuffer, InternalDistancesMatrices, SharedDistanceMatrices
 from ._structs import KernelInput, CartesianSelector, OrientationSurfacePointsCoords
 from .execution_mode import KernelExecutionMode
 from ...core.backend_tensor import BackendTensor as bt, BackendTensor
@@ -44,6 +44,8 @@ def create_scalar_kernel(
         ki: KernelInput,
         options: KernelOptions,
         execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+        distance_buffer: DistancesBuffer | None = None,
+        distance_cache_key: object = None,
 ) -> tensor_types:
     kernel_f = options.kernel_function.value
     a = options.range
@@ -56,6 +58,8 @@ def create_scalar_kernel(
         square_distance=kernel_f.consume_sq_distance,
         is_gradient=False,
         execution_mode=execution_mode,
+        distance_buffer=distance_buffer,
+        distance_cache_key=distance_cache_key,
     )
 
     k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest = _compute_all_kernel_terms(
@@ -117,6 +121,8 @@ def create_grad_kernel(
         ki: KernelInput,
         options: KernelOptions,
         execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+        distance_buffer: DistancesBuffer | None = None,
+        distance_cache_key: object = None,
 ) -> tensor_types:
     kernel_f = options.kernel_function.value
     a = options.range
@@ -128,6 +134,8 @@ def create_grad_kernel(
         square_distance=kernel_f.consume_sq_distance,
         is_gradient=True,
         execution_mode=execution_mode,
+        distance_buffer=distance_buffer,
+        distance_cache_key=distance_cache_key,
     )
 
     k_a, k_p_ref, k_p_rest, k_ref_ref, k_ref_rest, k_rest_ref, k_rest_rest = \
@@ -170,8 +178,59 @@ def _compute_all_kernel_terms(range_: int, kernel_functions: KernelFunction, r_r
 # noinspection DuplicatedCode
 def _compute_all_distance_matrices(cs: CartesianSelector, ori_sp_matrices: OrientationSurfacePointsCoords,
                                    square_distance: bool, is_gradient: bool, is_testing: bool = False,
-                                   execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE) -> InternalDistancesMatrices:
-    return _compute_distances_generic(cs, ori_sp_matrices, square_distance, execution_mode)
+                                   execution_mode: KernelExecutionMode = KernelExecutionMode.DENSE,
+                                   distance_buffer: DistancesBuffer | None = None,
+                                   distance_cache_key: object = None) -> InternalDistancesMatrices:
+    matrix_shape = (
+        ori_sp_matrices.dip_ref_i.shape[0],
+        ori_sp_matrices.dip_ref_j.shape[1],
+        ori_sp_matrices.dip_ref_i.shape[-1],
+    )
+    if (
+            is_gradient
+            and distance_buffer is not None
+            and distance_cache_key is not None
+            and distance_buffer.matches(distance_cache_key, matrix_shape, square_distance, execution_mode)
+    ):
+        return _compute_distances_using_cache(cs, distance_buffer.shared)
+
+    distance_matrices = _compute_distances_generic(cs, ori_sp_matrices, square_distance, execution_mode)
+    if not is_gradient and distance_buffer is not None and distance_cache_key is not None:
+        distance_buffer.store(distance_matrices, distance_cache_key, matrix_shape, square_distance, execution_mode)
+    return distance_matrices
+
+
+def _compute_distances_using_cache(
+        cs: CartesianSelector,
+        shared: SharedDistanceMatrices,
+) -> InternalDistancesMatrices:
+    dif_ref_ref = shared.dif_ref_ref
+    dif_rest_rest = shared.dif_rest_rest
+
+    hv = -bt.t.sum(dif_ref_ref * (cs.hv_sel_i * cs.hv_sel_j), axis=-1)
+    hv_ref = bt.t.sum(dif_ref_ref * (cs.h_sel_ref_i * cs.hv_sel_j), axis=-1)
+    hv_rest = bt.t.sum(dif_rest_rest * (cs.h_sel_rest_i * cs.hv_sel_j), axis=-1)
+    perp_matrix = bt.t.sum(cs.hu_sel_i * cs.hv_sel_j, axis=-1, dtype="int8")
+    hu_ref_grad = bt.t.sum(dif_ref_ref * (cs.h_sel_ref_i * cs.hu_sel_j), axis=-1)
+    hu_rest_grad = bt.t.sum(dif_rest_rest * (cs.h_sel_ref_i * cs.hu_sel_j), axis=-1)
+
+    return InternalDistancesMatrices(
+        dif_ref_ref=dif_ref_ref,
+        dif_rest_rest=dif_rest_rest,
+        hu=shared.hu,
+        hv=hv,
+        huv_ref=shared.hu_ref - hv_ref,
+        huv_rest=shared.hu_rest - hv_rest,
+        perp_matrix=perp_matrix,
+        r_ref_ref=shared.r_ref_ref,
+        r_ref_rest=shared.r_ref_rest,
+        r_rest_ref=shared.r_rest_ref,
+        r_rest_rest=shared.r_rest_rest,
+        hu_ref=shared.hu_ref,
+        hu_rest=shared.hu_rest,
+        hu_ref_grad=hu_ref_grad,
+        hu_rest_grad=hu_rest_grad,
+    )
 
 
 def _compute_distances_generic(

--- a/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
+++ b/gempy_engine/modules/kernel_constructor/kernel_constructor_interface.py
@@ -4,6 +4,7 @@ from ...core.data.kernel_classes.orientations import OrientationsInternals
 
 from ._b_vector_assembler import b_vector_assembly
 from ._kernels_assembler import create_cov_kernel, create_scalar_kernel, create_grad_kernel
+from ._internalDistancesMatrices import DistancesBuffer
 from ._vectors_preparation import cov_vectors_preparation, evaluation_vectors_preparations
 from .execution_mode import KernelExecutionMode
 from ...core.data.options import KernelOptions
@@ -25,16 +26,52 @@ def yield_b_vector(ori_internals: OrientationsInternals, cov_size: int) -> tenso
     return b_vector_assembly(ori_internals, cov_size)
 
 
-def yield_evaluation_kernel(interp_input: SolverInput, kernel_options: KernelOptions, slice_array = None, pykeops: bool = False):
+def yield_evaluation_kernel(
+        interp_input: SolverInput,
+        kernel_options: KernelOptions,
+        slice_array=None,
+        pykeops: bool = False,
+        distance_buffer: DistancesBuffer | None = None,
+):
+    distance_cache_key = _distance_cache_key(interp_input, slice_array)
     
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis=None, slice_array=slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
     execution_mode = KernelExecutionMode.SYMBOLIC if pykeops else KernelExecutionMode.DENSE
-    return create_scalar_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
+    return create_scalar_kernel(
+        kernel_data,
+        kernel_options,
+        execution_mode=execution_mode,
+        distance_buffer=distance_buffer,
+        distance_cache_key=distance_cache_key,
+    )
 
 
-def yield_evaluation_grad_kernel(interp_input: SolverInput, kernel_options: KernelOptions, axis: int = 0, slice_array = None, pykeops: bool = False):
+def yield_evaluation_grad_kernel(
+        interp_input: SolverInput,
+        kernel_options: KernelOptions,
+        axis: int = 0,
+        slice_array=None,
+        pykeops: bool = False,
+        distance_buffer: DistancesBuffer | None = None,
+):
+    distance_cache_key = _distance_cache_key(interp_input, slice_array)
     kernel_data = evaluation_vectors_preparations(interp_input, kernel_options, axis, slice_array)
     if pykeops: kernel_data = kernel_data.upgrade_tensors()
     execution_mode = KernelExecutionMode.SYMBOLIC if pykeops else KernelExecutionMode.DENSE
-    return create_grad_kernel(kernel_data, kernel_options, execution_mode=execution_mode)
+    return create_grad_kernel(
+        kernel_data,
+        kernel_options,
+        execution_mode=execution_mode,
+        distance_buffer=distance_buffer,
+        distance_cache_key=distance_cache_key,
+    )
+
+
+def _distance_cache_key(interp_input: SolverInput, slice_array) -> tuple[int, tuple[int | None, int | None, int | None] | None]:
+    slice_key = (
+        (slice_array.start, slice_array.stop, slice_array.step)
+        if isinstance(slice_array, slice)
+        else None
+    )
+    return id(interp_input), slice_key

--- a/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
+++ b/tests/test_common/test_modules/test_kernel_constructor/test_kernel_constructor.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
 from approvaltests import Options
@@ -12,6 +14,8 @@ from gempy_engine.core.data.internal_structs import SolverInput
 from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
 from gempy_engine.core.data.matrices_sizes import MatricesSizes
 
+from gempy_engine.modules.kernel_constructor import _kernels_assembler
+from gempy_engine.modules.kernel_constructor._internalDistancesMatrices import DistancesBuffer
 from gempy_engine.modules.kernel_constructor._kernels_assembler import _compute_all_distance_matrices, create_scalar_kernel, create_grad_kernel
 from gempy_engine.modules.kernel_constructor._test_assembler import _test_covariance_items
 from gempy_engine.modules.data_preprocess._input_preparation import surface_points_preprocess, \
@@ -80,6 +84,156 @@ def test_eval_kernel(simple_model_2, simple_grid_2d):
 
     export_gradient_ = create_grad_kernel(kernel_data, options.kernel_options)
     print(export_gradient_)
+
+
+def test_distance_buffer_reuses_scalar_distances_for_all_gradient_axes(simple_model_2, simple_grid_2d, monkeypatch):
+    surface_points, orientations, options, input_data_descriptor = simple_model_2
+    grid = BackendTensor.t.array(simple_grid_2d)
+    solver_input = SolverInput(
+        surface_points_preprocess(surface_points, input_data_descriptor.tensors_structure),
+        orientations_preprocess(orientations),
+    )
+    solver_input.xyz_to_interpolate = grid
+    square_distance = options.kernel_options.kernel_function.value.consume_sq_distance
+    distance_buffer = DistancesBuffer()
+    distance_cache_key = object()
+    generic_calls = 0
+    original_compute = _kernels_assembler._compute_distances_generic
+
+    def count_generic_calls(*args, **kwargs):
+        nonlocal generic_calls
+        generic_calls += 1
+        return original_compute(*args, **kwargs)
+
+    monkeypatch.setattr(_kernels_assembler, "_compute_distances_generic", count_generic_calls)
+    scalar_data = evaluation_vectors_preparations(solver_input, options.kernel_options)
+    scalar_distances = _compute_all_distance_matrices(
+        scalar_data.cartesian_selector,
+        scalar_data.ori_sp_matrices,
+        square_distance,
+        is_gradient=False,
+        distance_buffer=distance_buffer,
+        distance_cache_key=distance_cache_key,
+    )
+
+    cached_gradient_distances = []
+    for axis in range(options.kernel_options.number_dimensions):
+        gradient_data = evaluation_vectors_preparations(solver_input, options.kernel_options, axis=axis)
+        cached_gradient_distances.append(_compute_all_distance_matrices(
+            gradient_data.cartesian_selector,
+            gradient_data.ori_sp_matrices,
+            square_distance,
+            is_gradient=True,
+            distance_buffer=distance_buffer,
+            distance_cache_key=distance_cache_key,
+        ))
+
+    assert generic_calls == 1
+    assert all(distances.dif_ref_ref is scalar_distances.dif_ref_ref for distances in cached_gradient_distances)
+
+    for axis, cached_distances in enumerate(cached_gradient_distances):
+        gradient_data = evaluation_vectors_preparations(solver_input, options.kernel_options, axis=axis)
+        uncached_distances = original_compute(
+            gradient_data.cartesian_selector,
+            gradient_data.ori_sp_matrices,
+            square_distance,
+        )
+        for field_name in cached_distances.__dataclass_fields__:
+            np.testing.assert_allclose(
+                BackendTensor.t.to_numpy(getattr(cached_distances, field_name)),
+                BackendTensor.t.to_numpy(getattr(uncached_distances, field_name)),
+            )
+
+
+def test_distance_buffers_are_isolated_between_concurrent_equal_shaped_inputs(simple_model_2, simple_grid_2d):
+    surface_points, orientations, options, input_data_descriptor = simple_model_2
+    sp_internal = surface_points_preprocess(surface_points, input_data_descriptor.tensors_structure)
+    ori_internal = orientations_preprocess(orientations)
+    square_distance = options.kernel_options.kernel_function.value.consume_sq_distance
+
+    def compute_distances(grid_offset):
+        grid = BackendTensor.t.array(simple_grid_2d) + grid_offset
+        solver_input = SolverInput(sp_internal, ori_internal)
+        solver_input.xyz_to_interpolate = grid
+        distance_buffer = DistancesBuffer()
+        distance_cache_key = object()
+        scalar_data = evaluation_vectors_preparations(solver_input, options.kernel_options)
+        _compute_all_distance_matrices(
+            scalar_data.cartesian_selector,
+            scalar_data.ori_sp_matrices,
+            square_distance,
+            is_gradient=False,
+            distance_buffer=distance_buffer,
+            distance_cache_key=distance_cache_key,
+        )
+        gradient_data = evaluation_vectors_preparations(solver_input, options.kernel_options, axis=0)
+        cached = _compute_all_distance_matrices(
+            gradient_data.cartesian_selector,
+            gradient_data.ori_sp_matrices,
+            square_distance,
+            is_gradient=True,
+            distance_buffer=distance_buffer,
+            distance_cache_key=distance_cache_key,
+        )
+        uncached = _kernels_assembler._compute_distances_generic(
+            gradient_data.cartesian_selector,
+            gradient_data.ori_sp_matrices,
+            square_distance,
+        )
+        return (
+            BackendTensor.t.to_numpy(cached.r_ref_ref),
+            BackendTensor.t.to_numpy(uncached.r_ref_ref),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(compute_distances, (0.0, 0.125)))
+
+    for cached, uncached in results:
+        np.testing.assert_allclose(cached, uncached)
+    assert not np.allclose(results[0][0], results[1][0])
+
+
+def test_distance_buffer_rejects_an_equal_shaped_input_with_a_different_cache_key(simple_model_2, simple_grid_2d):
+    surface_points, orientations, options, input_data_descriptor = simple_model_2
+    sp_internal = surface_points_preprocess(surface_points, input_data_descriptor.tensors_structure)
+    ori_internal = orientations_preprocess(orientations)
+    square_distance = options.kernel_options.kernel_function.value.consume_sq_distance
+    distance_buffer = DistancesBuffer()
+
+    first_input = SolverInput(sp_internal, ori_internal)
+    first_input.xyz_to_interpolate = BackendTensor.t.array(simple_grid_2d)
+    first_scalar_data = evaluation_vectors_preparations(first_input, options.kernel_options)
+    _compute_all_distance_matrices(
+        first_scalar_data.cartesian_selector,
+        first_scalar_data.ori_sp_matrices,
+        square_distance,
+        is_gradient=False,
+        distance_buffer=distance_buffer,
+        distance_cache_key="first-input",
+    )
+
+    second_input = SolverInput(sp_internal, ori_internal)
+    second_input.xyz_to_interpolate = BackendTensor.t.array(simple_grid_2d) + 0.125
+    second_gradient_data = evaluation_vectors_preparations(second_input, options.kernel_options, axis=0)
+    result = _compute_all_distance_matrices(
+        second_gradient_data.cartesian_selector,
+        second_gradient_data.ori_sp_matrices,
+        square_distance,
+        is_gradient=True,
+        distance_buffer=distance_buffer,
+        distance_cache_key="second-input",
+    )
+    expected = _kernels_assembler._compute_distances_generic(
+        second_gradient_data.cartesian_selector,
+        second_gradient_data.ori_sp_matrices,
+        square_distance,
+    )
+
+    np.testing.assert_allclose(
+        BackendTensor.t.to_numpy(result.r_ref_ref),
+        BackendTensor.t.to_numpy(expected.r_ref_ref),
+    )
+    assert result.dif_ref_ref is not distance_buffer.shared.dif_ref_ref
 
 
 backendNOTNumpyOrNotEnoughRequirementsInstalled = (BackendTensor.engine_backend != AvailableBackends.numpy or


### PR DESCRIPTION
Introduces `DistancesBuffer` and `SharedDistanceMatrices` to enable caching of distance matrices. Enhances kernel creation and evaluation functions to reuse cached matrices across multiple gradient computations, reducing redundant calculations. Updates kernel interfaces, evaluators, and tests to support and validate caching behavior.