### PR TITLE
[ENH] Wire finite-fault definitions into fault stack interpolation

### DIFF
--- a/docs/implementation/finite_faults.md
+++ b/docs/implementation/finite_faults.md
@@ -6,8 +6,9 @@ Define finite faults as validated, serializable input data and use that
 definition to taper fault displacement on the interpolated fault surface.
 
 The implementation is based on the projection and UV taper prototype in
-`gempy_engine/modules/faults/finite_faults.py`. The prototype is useful, but it
-is not yet connected to the engine's older callable-based finite-fault hook.
+`gempy_engine/modules/faults/finite_faults.py`. Its declarative input is now
+connected to fault-stack interpolation; geometric and backend validation remain
+for Phase 4.
 
 ## Status
 
@@ -30,13 +31,13 @@ is not yet connected to the engine's older callable-based finite-fault hook.
 
 ### Phase 3: Stack wiring
 
-- [ ] Replace the callable in `FiniteFaultData` with the declarative definition.
-- [ ] Associate at most one finite-fault definition with each fault stack.
-- [ ] Validate that definitions are attached only to `StackRelationType.FAULT` stacks.
-- [ ] Make scalar gradients available when a finite-fault stack is evaluated.
-- [ ] Pass the fault scalar field, gradients, and surface isovalue to the taper operation.
-- [ ] Apply the taper to the fault drift before dependent stacks are interpolated.
-- [ ] Cover both sequential and flat-stack interpolation paths.
+- [x] Replace the callable in `FiniteFaultData` with the declarative definition.
+- [x] Associate at most one finite-fault definition with each fault stack.
+- [x] Validate that definitions are attached only to `StackRelationType.FAULT` stacks.
+- [x] Make scalar gradients available when a finite-fault stack is evaluated.
+- [x] Pass the fault scalar field, gradients, and surface isovalue to the taper operation.
+- [x] Apply the taper to the fault drift before dependent stacks are interpolated.
+- [x] Cover both sequential and flat-stack interpolation paths.
 
 ### Phase 4: Integration and backend support
 
@@ -136,11 +137,45 @@ when its scalar residual is within `surface_tolerance`. Otherwise projection is
 undefined and the function raises `ValueError`. Tolerances are keyword-only and
 must be non-negative.
 
+## Stack Attachment
+
+The finite-fault definition belongs to the stack that interpolates the fault.
+Attach it through that stack's `FaultsData` entry:
+
+```python
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
+
+fault_data = FaultsData.from_user_input(
+    thickness=None,
+    finite_fault=finite_fault,
+)
+input_data_descriptor.stack_structure.faults_input_data = [
+    fault_data,
+    None,
+    None,
+]
+```
+
+`faults_input_data` must contain one entry per stack. A finite-fault definition
+is valid only on a cokriging stack with `StackRelationType.FAULT` and exactly one
+surface, because that surface supplies the projection isovalue.
+
+The engine privately enables scalar gradients for finite-fault stacks without
+changing the caller's global or per-stack options. The fault scalar field,
+full-length gradients, and surface isovalue are used to project all evaluation
+coordinates. A fixed local frame is taken from the valid projected point nearest
+the configured center. The resulting slip multiplier tapers the stored fault
+drift before dependent stacks read it.
+
+In flat-stack mode, finite-fault stacks are isolated into singleton chunks and
+use the non-stacked symbolic evaluator. Ordinary stacks continue to use the
+optimized stacked evaluator. NumPy and PyKeOps reductions can differ slightly
+because their floating-point reduction orders are different.
+
 ## Known Prototype Issues
 
-- `FiniteFault.calculate_slip` expects callers to project points separately.
+- Standalone `FiniteFault.calculate_slip` expects callers to project points separately; engine stack wiring performs that projection.
 - The local strike/dip frame is constant and therefore approximates curved faults.
-- The engine-integrated `FiniteFaultData` loses its callable when serialized.
 - Existing integration assertions do not verify the projected surface residual or expected geometry.
 
 ## Design Decisions

--- a/gempy_engine/API/interp_single/_aux_faults_ops.py
+++ b/gempy_engine/API/interp_single/_aux_faults_ops.py
@@ -2,6 +2,9 @@ import numpy as np
 
 from gempy_engine.core.backend_tensor import BackendTensor
 from gempy_engine.core.data.kernel_classes.faults import FaultsData
+from gempy_engine.core.data.options import InterpolationOptions
+from gempy_engine.core.data.scalar_field_output import ScalarFieldOutput
+from gempy_engine.modules.faults.finite_faults import project_points_onto_surface
 
 
 def _grab_stack_fault_data(_all_stack_values_block, _interpolation_input_i, _stack_structure, grid_size:int) -> FaultsData:
@@ -13,16 +16,67 @@ def _grab_stack_fault_data(_all_stack_values_block, _interpolation_input_i, _sta
 
 
 
-def _modify_faults_values_output(fault_input: FaultsData, values_on_all_xyz: np.ndarray,
-                                 xyz_to_interpolate: np.ndarray) -> np.ndarray:
+def _options_with_finite_fault_gradients(
+        options: InterpolationOptions,
+        fault_input: FaultsData | None,
+) -> InterpolationOptions:
+    if fault_input is None or not fault_input.finite_fault_defined or options.evaluation_options.compute_scalar_gradient:
+        return options
+
+    options_copy = options.model_copy(deep=True)
+    options_copy.evaluation_options.compute_scalar_gradient = True
+    return options_copy
+
+
+def _modify_faults_values_output(
+        fault_input: FaultsData,
+        output: ScalarFieldOutput,
+        xyz_to_interpolate: np.ndarray,
+) -> np.ndarray:
+    values_on_all_xyz = output.values_on_all_xyz
     val_min = BackendTensor.t.min(values_on_all_xyz, axis=1).reshape(-1, 1)  # ? Is this as good as it gets?
     shifted_vals = (values_on_all_xyz - val_min)  # * Shift values between 0 and 1... hopefully
-    if fault_input.finite_faults_defined:
-        # TODO: Rescale scalar field parameters
-        finite_fault_scalar: np.ndarray = fault_input.finite_fault_data.apply(
-            points=xyz_to_interpolate
-        )
-        fault_scalar_field = shifted_vals * finite_fault_scalar
-    else:
-        fault_scalar_field = shifted_vals
-    return fault_scalar_field
+    if not fault_input.finite_fault_defined:
+        return shifted_vals
+
+    exported_fields = output.exported_fields
+    gradients = (
+        exported_fields.gx_field_everywhere,
+        exported_fields.gy_field_everywhere,
+        exported_fields.gz_field_everywhere,
+    )
+    if any(gradient is None for gradient in gradients):
+        raise ValueError("Finite-fault projection requires scalar gradients")
+
+    to_numpy = BackendTensor.t.to_numpy
+    xyz_np = np.asarray(to_numpy(xyz_to_interpolate))
+    scalar_field_np = np.asarray(to_numpy(exported_fields.scalar_field_everywhere))
+    gradients_np = tuple(np.asarray(to_numpy(gradient)) for gradient in gradients)
+    target_values = np.asarray(to_numpy(output.scalar_field_at_sp)).reshape(-1)
+    if target_values.size != 1:
+        raise ValueError("Finite-fault projection requires exactly one fault surface isovalue")
+
+    projected_points = project_points_onto_surface(
+        points=xyz_np,
+        scalar_field_values=scalar_field_np,
+        gradient_fields=gradients_np,
+        target_scalar_value=float(target_values[0]),
+    )
+
+    gradient_matrix = np.stack(gradients_np, axis=-1)
+    valid_gradient = np.linalg.norm(gradient_matrix, axis=1) > 1e-12
+    if not np.any(valid_gradient):
+        raise ValueError("Cannot determine finite-fault frame from near-zero gradients")
+
+    center = np.asarray(fault_input.finite_fault.center)
+    distances_to_center = np.linalg.norm(projected_points - center, axis=1)
+    center_index = np.argmin(np.where(valid_gradient, distances_to_center, np.inf))
+    finite_fault_scalar_np = fault_input.finite_fault.calculate_slip(
+        points=projected_points,
+        normal=gradient_matrix[center_index],
+    )
+    finite_fault_scalar = BackendTensor.t.array(
+        finite_fault_scalar_np,
+        dtype=shifted_vals.dtype,
+    )
+    return shifted_vals * finite_fault_scalar

--- a/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
+++ b/gempy_engine/API/interp_single/_multi_scalar_field_manager.py
@@ -3,7 +3,7 @@ from typing import List
 
 import numpy as np
 
-from ._aux_faults_ops import _grab_stack_fault_data, _modify_faults_values_output
+from ._aux_faults_ops import _grab_stack_fault_data, _modify_faults_values_output, _options_with_finite_fault_gradients
 from ._interp_single_feature import input_preprocess, interpolate_feature_with_cokrig, interpolate_feature_with_external_function
 from ._masking_ops import combine_scalar_fields
 from ._stack_ops import InterpolationState, process_chunk
@@ -105,6 +105,7 @@ def _interpolate_stack(root_data_descriptor: InputDataDescriptor, root_interpola
 
         # Check for stack specific options override
         options_i = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
+        options_i = _options_with_finite_fault_gradients(options_i, stack_structure.active_faults_input_data)
 
         if stack_structure.interp_function is not None:
             # External function path - skip tensor/solver prep (may have zero points/orientations)
@@ -152,7 +153,7 @@ def _interpolate_stack(root_data_descriptor: InputDataDescriptor, root_interpola
         if interpolation_input_i.stack_relation is StackRelationType.FAULT:  # * This is also for faults!
             values_output = _modify_faults_values_output(  # ! This is all_STACK_values_block (not all_scalar_fields_outputs)
                 fault_input=fault_input,
-                values_on_all_xyz=output.values_on_all_xyz,
+                output=output,
                 xyz_to_interpolate=solver_input.xyz_to_interpolate
             )
             all_stack_values_block[i, :] = values_output
@@ -167,8 +168,8 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
     Stacks are processed in chunks where all stacks in a chunk have their
     fault dependencies already resolved by previous chunks.
     
-    External-function stacks are always emitted as singleton chunks so they
-    are never batched into PyKeOps stacked solver/evaluator calls.
+    External-function and finite-fault stacks are emitted as singleton chunks
+    so they can use evaluation behavior that differs from ordinary stacks.
     """
 
     faults_relations = stack_structure.faults_relations
@@ -176,8 +177,10 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
     n_stacks = stack_structure.n_stacks
 
     external_stacks = _get_external_stack_indices(stack_structure)
+    finite_fault_stacks = _get_finite_fault_stack_indices(stack_structure)
+    isolated_stacks = external_stacks | finite_fault_stacks
 
-    if faults_relations is None and not external_stacks:
+    if faults_relations is None and not isolated_stacks:
         return [list(range(n_stacks))]
 
     fault_stacks = {i for i in range(n_stacks) if masking_descriptor[i] is StackRelationType.FAULT}
@@ -198,12 +201,12 @@ def _compute_independent_chunks(stack_structure: StacksStructure, len_grid: int)
         if not chunk:
             raise RuntimeError("Circular fault dependency detected")
 
-        normal = [i for i in chunk if i not in external_stacks]
-        external_subchunks = [[i] for i in chunk if i in external_stacks]
+        normal = [i for i in chunk if i not in isolated_stacks]
+        isolated_subchunks = [[i] for i in chunk if i in isolated_stacks]
 
         if normal:
             chunks.append(normal)
-        chunks.extend(external_subchunks)
+        chunks.extend(isolated_subchunks)
 
         remaining -= set(chunk)
         resolved.update(i for i in chunk if i in fault_stacks)
@@ -243,3 +246,12 @@ def _get_external_stack_indices(stack_structure: StacksStructure) -> set[int]:
     if stack_structure.interp_functions_per_stack is None:
         return set()
     return {i for i, f in enumerate(stack_structure.interp_functions_per_stack) if f is not None}
+
+
+def _get_finite_fault_stack_indices(stack_structure: StacksStructure) -> set[int]:
+    if stack_structure.faults_input_data is None:
+        return set()
+    return {
+        i for i, fault_data in enumerate(stack_structure.faults_input_data)
+        if fault_data is not None and fault_data.finite_fault_defined
+    }

--- a/gempy_engine/API/interp_single/_stack_ops.py
+++ b/gempy_engine/API/interp_single/_stack_ops.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 
-from ._aux_faults_ops import _grab_stack_fault_data, _modify_faults_values_output
+from ._aux_faults_ops import _grab_stack_fault_data, _modify_faults_values_output, _options_with_finite_fault_gradients
 from ._interp_scalar_field import _evaluate_sys_eq, compute_weights
 from ._interp_single_feature import interpolate_feature_with_external_function
 from ...config import AvailableBackends
@@ -46,6 +46,7 @@ def process_chunk(state: InterpolationState, chunk: list[int]):
     # region preparation - build inputs for this chunk
     chunk_interpolation_inputs: list[InterpolationInput] = []
     chunk_tensor_structs: list[TensorsStructure] = []
+    chunk_options: list[InterpolationOptions] = []
 
     if BackendTensor.engine_backend == AvailableBackends.PYTORCH and BackendTensor.use_gpu:
         import torch
@@ -72,6 +73,9 @@ def process_chunk(state: InterpolationState, chunk: list[int]):
         state.tensor_structs[i] = tensor_struct_i
         chunk_interpolation_inputs.append(interpolation_input_i)
         chunk_tensor_structs.append(tensor_struct_i)
+
+        options_i = state.stack_structure.interpolation_options if state.stack_structure.interpolation_options is not None else state.options
+        chunk_options.append(_options_with_finite_fault_gradients(options_i, fault_input))
     # endregion
 
     # Compute weights for this chunk
@@ -80,20 +84,33 @@ def process_chunk(state: InterpolationState, chunk: list[int]):
         options=state.options,
         stack_structure=state.stack_structure,
         tensor_structs=chunk_tensor_structs,
-        stack_indices=chunk
+        stack_indices=chunk,
+        options_per_stack=chunk_options,
     )
     for idx, i in enumerate(chunk):
         state.solver_inputs[i] = chunk_solver_inputs[idx]
 
     # Evaluate this chunk
-    chunk_eval_inputs, chunk_exported_fields = _evaluate_optimized(
-        interpolation_inputs=chunk_interpolation_inputs,
-        options=state.options,
-        solver_inputs=chunk_solver_inputs,
-        stack_structure=state.stack_structure,
-        tensor_structs=chunk_tensor_structs,
-        stack_indices=chunk
-    )
+    if any(fault_input.finite_fault_defined for fault_input in (item.fault_values for item in chunk_interpolation_inputs)):
+        chunk_eval_inputs, chunk_exported_fields = _evaluate(
+            interpolation_inputs=chunk_interpolation_inputs,
+            options=state.options,
+            solver_inputs=chunk_solver_inputs,
+            stack_structure=state.stack_structure,
+            tensor_structs=chunk_tensor_structs,
+            stack_indices=chunk,
+            options_per_stack=chunk_options,
+        )
+    else:
+        chunk_eval_inputs, chunk_exported_fields = _evaluate_optimized(
+            interpolation_inputs=chunk_interpolation_inputs,
+            options=state.options,
+            solver_inputs=chunk_solver_inputs,
+            stack_structure=state.stack_structure,
+            tensor_structs=chunk_tensor_structs,
+            stack_indices=chunk,
+            options_per_stack=chunk_options,
+        )
 
     for idx, i in enumerate(chunk):
         state.eval_inputs[i] = chunk_eval_inputs[idx]
@@ -106,7 +123,8 @@ def process_chunk(state: InterpolationState, chunk: list[int]):
         options=state.options,
         solver_inputs=chunk_solver_inputs,
         stack_structure=state.stack_structure,
-        stack_indices=chunk
+        stack_indices=chunk,
+        options_per_stack=chunk_options,
     )
 
     for idx, i in enumerate(chunk):
@@ -119,7 +137,7 @@ def process_chunk(state: InterpolationState, chunk: list[int]):
 
         values_output = _modify_faults_values_output(
             fault_input=chunk_interpolation_inputs[idx].fault_values,
-            values_on_all_xyz=state.all_scalar_fields_outputs[i].values_on_all_xyz,
+            output=state.all_scalar_fields_outputs[i],
             xyz_to_interpolate=state.eval_inputs[i].xyz_to_interpolate
         )
         state.all_stack_values_block[i, :] = values_output
@@ -132,7 +150,8 @@ def _segment(
         options: InterpolationOptions,
         solver_inputs,
         stack_structure: StacksStructure,
-        stack_indices: list[int]
+        stack_indices: list[int],
+        options_per_stack: list[InterpolationOptions],
 ) -> list[ScalarFieldOutput | None]:
     def _run_segment(idx_global_i: tuple[int, int]) -> ScalarFieldOutput:
         idx, global_i = idx_global_i
@@ -141,8 +160,7 @@ def _segment(
         local_stack_structure = copy(stack_structure)
         local_stack_structure.stack_number = global_i
 
-        # Check for stack specific options override
-        options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+        options_i = options_per_stack[idx]
 
         import torch
         if torch.cuda.is_available():
@@ -188,7 +206,8 @@ def _segment(
 
 
 def _evaluate(interpolation_inputs: list[InterpolationInput], options: InterpolationOptions, solver_inputs, stack_structure: StacksStructure,
-              tensor_structs: list[TensorsStructure], stack_indices: list[int] | None = None) -> tuple[list[EvaluatorInput], list[ExportedFields]]:
+              tensor_structs: list[TensorsStructure], stack_indices: list[int] | None = None,
+              options_per_stack: list[InterpolationOptions] | None = None) -> tuple[list[EvaluatorInput], list[ExportedFields]]:
     eval_inputs: list[EvaluatorInput] = []
     exported_fields_per_stack: list[ExportedFields] = []
     for idx, global_i in enumerate(stack_indices):
@@ -205,7 +224,7 @@ def _evaluate(interpolation_inputs: list[InterpolationInput], options: Interpola
         exported_fields: ExportedFields = _evaluate_sys_eq(
             eval_input=eval_input,
             weights=eval_input.solver_input.weights_x0,
-            options=options
+            options=options_per_stack[idx] if options_per_stack is not None else options,
         )
 
         exported_fields.set_structure_values_from_eval_input(eval_input)
@@ -218,7 +237,8 @@ def _evaluate(interpolation_inputs: list[InterpolationInput], options: Interpola
 
 
 def _evaluate_optimized(interpolation_inputs: list[InterpolationInput], options: InterpolationOptions, solver_inputs, stack_structure: StacksStructure,
-                        tensor_structs: list[TensorsStructure], stack_indices: list[int] | None = None) -> tuple[list[EvaluatorInput], list[ExportedFields]]:
+                         tensor_structs: list[TensorsStructure], stack_indices: list[int] | None = None,
+                         options_per_stack: list[InterpolationOptions] | None = None) -> tuple[list[EvaluatorInput], list[ExportedFields]]:
     from gempy_engine.modules.evaluator.symbolic_evaluator import symbolic_evaluator_optimized_stacked
 
     eval_inputs: list[EvaluatorInput] = []
@@ -236,12 +256,7 @@ def _evaluate_optimized(interpolation_inputs: list[InterpolationInput], options:
     # Collect weights per stack
     weights_list = [ei.solver_input.weights_x0 for ei in eval_inputs]
 
-    # Collect options per stack
-    options_list = []
-    for global_i in stack_indices:
-        stack_structure.stack_number = global_i
-        opt_i = stack_structure.interpolation_options if stack_structure.interpolation_options is not None else options
-        options_list.append(opt_i)
+    options_list = options_per_stack or [options] * len(stack_indices)
 
     # Call the stacked evaluator (single PyKeOps call with block-sparse ranges)
     exported_fields_list: list[ExportedFields] = symbolic_evaluator_optimized_stacked(
@@ -262,7 +277,8 @@ def _compute_weights_for_stacks(
         options: InterpolationOptions,
         stack_structure: StacksStructure,
         tensor_structs: list[TensorsStructure],
-        stack_indices: list[int] | None = None
+        stack_indices: list[int] | None = None,
+        options_per_stack: list[InterpolationOptions] | None = None,
 ) -> list[SolverInput_v2]:
     if stack_indices is None:
         stack_indices = list(range(stack_structure.n_stacks))
@@ -274,8 +290,7 @@ def _compute_weights_for_stacks(
         local_stack_structure = copy(stack_structure)
         local_stack_structure.stack_number = global_i
 
-        # Check for stack specific options override
-        options_i = local_stack_structure.interpolation_options if local_stack_structure.interpolation_options is not None else options
+        options_i = options_per_stack[idx] if options_per_stack is not None else options
 
         import torch
         if torch.cuda.is_available():

--- a/gempy_engine/API/model/model_api.py
+++ b/gempy_engine/API/model/model_api.py
@@ -16,6 +16,7 @@ from ...core.data.interp_output import InterpOutput
 from ...core.data.interpolation_input import InterpolationInput
 from ...core.data.octree_level import OctreeLevel
 from ...core.data.solutions import Solutions
+from ...core.data.stack_relation_type import StackRelationType
 from ...core.utils import gempy_profiler_decorator
 from ...core.exceptions import GemPyEngineInputError
 from ...core.data.options.temp_interpolation_values import TempInterpolationValues
@@ -224,6 +225,28 @@ def _check_input_validity(interpolation_input: InterpolationInput, options: Inte
                     f"Validation Error: Stack {stack_index} has no orientations. "
                     f"Each stack must have at least one orientation, unless it uses an external interpolation function."
                 )
+
+        # 3.6 Finite-fault definitions belong to single-surface fault stacks
+        if ss.faults_input_data is not None:
+            if len(ss.faults_input_data) != ss.n_stacks:
+                raise GemPyEngineInputError(
+                    "Validation Error: faults_input_data must contain one entry per stack."
+                )
+            for stack_index, fault_data in enumerate(ss.faults_input_data):
+                if fault_data is None or not fault_data.finite_fault_defined:
+                    continue
+                if ss.masking_descriptor[stack_index] is not StackRelationType.FAULT:
+                    raise GemPyEngineInputError(
+                        f"Validation Error: Finite-fault definition on stack {stack_index} requires a FAULT stack."
+                    )
+                if ss.number_of_surfaces_per_stack[stack_index] != 1:
+                    raise GemPyEngineInputError(
+                        f"Validation Error: Finite-fault stack {stack_index} must contain exactly one surface."
+                    )
+                if _stack_uses_external_function(ss, stack_index):
+                    raise GemPyEngineInputError(
+                        f"Validation Error: Finite-fault stack {stack_index} requires cokriging evaluation."
+                    )
 
     # 4. Check surfaces consistency
     # 4.1 Each surface must have at least one surface point

--- a/gempy_engine/core/data/exported_fields.py
+++ b/gempy_engine/core/data/exported_fields.py
@@ -82,16 +82,28 @@ class ExportedFields:
         return self._gx_field[:self._grid_size]
 
     @property
+    def gx_field_everywhere(self):
+        return self._gx_field
+
+    @property
     def gy_field(self):
         if self._gy_field is None:
             return None
         return self._gy_field[:self._grid_size]
 
     @property
+    def gy_field_everywhere(self):
+        return self._gy_field
+
+    @property
     def gz_field(self):
         if self._gz_field is None:
             return None
         return self._gz_field[:self._grid_size]
+
+    @property
+    def gz_field_everywhere(self):
+        return self._gz_field
 
     @property
     def npf(self):

--- a/gempy_engine/core/data/kernel_classes/faults.py
+++ b/gempy_engine/core/data/kernel_classes/faults.py
@@ -1,30 +1,10 @@
 import dataclasses
-from typing import Optional, Callable
+from typing import Optional
 
 import numpy as np
-from pydantic import Field
 
 from ..encoders.converters import short_array_type
-from ..transforms import Transform
-
-
-@dataclasses.dataclass
-class FiniteFaultData:
-    implicit_function: Callable | None =  Field(exclude=True, default=None)#, default=None)
-    implicit_function_transform: Transform = Field()
-    pivot: short_array_type = Field()
-
-    def apply(self, points: np.ndarray) -> np.ndarray:
-        transformed_points = self.implicit_function_transform.apply_inverse_with_pivot(
-            points=points,
-            pivot=self.pivot
-        )
-        if self.implicit_function is None:
-            raise ValueError("No implicit function defined. This can happen after deserializing (loading).")
-        
-        scalar_block = self.implicit_function(transformed_points)
-        return scalar_block 
-        
+from ..finite_fault import FiniteFault
 
 
 @dataclasses.dataclass
@@ -37,27 +17,27 @@ class FaultsData:
     
     # User given data:
     thickness: Optional[float] = None
-    finite_fault_data: Optional[FiniteFaultData] = None  
+    finite_fault: Optional[FiniteFault] = None
     
     def __hash__(self):
         i = hash(self.__repr__())
         return i
 
     @classmethod
-    def from_user_input(cls, thickness: Optional[float]) -> "FaultsData":
+    def from_user_input(cls, thickness: Optional[float], finite_fault: Optional[FiniteFault] = None) -> "FaultsData":
         return cls(
             fault_values_everywhere=np.zeros(0),
             fault_values_on_sp=np.zeros(0),
             thickness=thickness,
+            finite_fault=finite_fault,
             fault_values_ref=np.zeros(0),
             fault_values_rest=np.zeros(0)
         )
-    
+
     @property
-    def finite_faults_defined(self) -> bool:
-        return self.finite_fault_data is not None
-    
+    def finite_fault_defined(self) -> bool:
+        return self.finite_fault is not None
+
     @property
     def n_faults(self):
         return self.fault_values_on_sp.shape[0]
-    

--- a/tests/test_common/test_api/test_faults/test_finite_fault_stack_wiring.py
+++ b/tests/test_common/test_api/test_faults/test_finite_fault_stack_wiring.py
@@ -1,0 +1,171 @@
+import copy
+
+import numpy as np
+import pytest
+
+from gempy_engine import compute_model
+from gempy_engine.API.interp_single._aux_faults_ops import (
+    _modify_faults_values_output,
+    _options_with_finite_fault_gradients,
+)
+from gempy_engine.API.interp_single._multi_scalar_field_manager import _compute_independent_chunks
+from gempy_engine.core.data import FiniteFault, InterpolationOptions
+from gempy_engine.core.backend_tensor import BackendTensor
+from gempy_engine.core.data.exported_fields import ExportedFields
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
+from gempy_engine.core.data.scalar_field_output import ScalarFieldOutput
+from gempy_engine.core.data.stack_relation_type import StackRelationType
+from gempy_engine.core.data.stacks_structure import StacksStructure
+
+
+def test_modify_fault_values_applies_projected_taper():
+    finite_fault = FiniteFault(center=(0.0, 0.0, 0.0), strike_radius=1.0, dip_radius=1.0)
+    fault_input = FaultsData.from_user_input(thickness=None, finite_fault=finite_fault)
+    points = np.array([
+            [2.0, 0.0, 2.0],
+            [0.0, 0.0, 2.0],
+            [1.0, 0.0, 2.0],
+    ])
+    exported_fields = ExportedFields(
+        _scalar_field=np.full(3, 2.0),
+        _gx_field=np.zeros(3),
+        _gy_field=np.zeros(3),
+        _gz_field=np.ones(3),
+        _grid_size=3,
+        _scalar_field_at_surface_points=np.array([0.0]),
+    )
+    output = ScalarFieldOutput(
+        weights=None,
+        grid=None,
+        exported_fields=exported_fields,
+        stack_relation=StackRelationType.FAULT,
+        values_block=np.array([[1.0, 3.0, 3.0]]),
+    )
+
+    tapered_values = _modify_faults_values_output(fault_input, output, points)
+
+    assert np.allclose(tapered_values, [[0.0, 2.0, 0.0]])
+
+
+def test_finite_fault_gradient_options_do_not_mutate_input():
+    options = InterpolationOptions.from_args(range=1.0, c_o=1.0, mesh_extraction=False)
+    fault_input = FaultsData.from_user_input(
+        thickness=None,
+        finite_fault=FiniteFault(center=(0.0, 0.0, 0.0)),
+    )
+
+    finite_fault_options = _options_with_finite_fault_gradients(options, fault_input)
+
+    assert finite_fault_options is not options
+    assert finite_fault_options.evaluation_options is not options.evaluation_options
+    assert finite_fault_options.evaluation_options.compute_scalar_gradient is True
+    assert options.evaluation_options.compute_scalar_gradient is False
+
+
+def test_finite_fault_stack_is_isolated_before_dependent_stack():
+    finite_fault_data = FaultsData.from_user_input(
+        thickness=None,
+        finite_fault=FiniteFault(center=(0.0, 0.0, 0.0)),
+    )
+    stack_structure = StacksStructure(
+        number_of_points_per_stack=np.array([3, 3, 3]),
+        number_of_orientations_per_stack=np.array([1, 1, 1]),
+        number_of_surfaces_per_stack=np.array([1, 1, 1]),
+        masking_descriptor=[StackRelationType.FAULT, StackRelationType.ERODE, StackRelationType.ERODE],
+        faults_relations=np.array([
+                [False, False, True],
+                [False, False, False],
+                [False, False, False],
+        ]),
+        faults_input_data=[finite_fault_data, None, None],
+    )
+
+    chunks = _compute_independent_chunks(stack_structure, len_grid=8)
+
+    assert [0] in chunks
+    assert chunks.index([0]) < next(i for i, chunk in enumerate(chunks) if 2 in chunk)
+    assert all(0 not in chunk or chunk == [0] for chunk in chunks)
+
+
+def test_finite_fault_is_wired_into_dependent_stack(one_fault_model):
+    interpolation_input, data_descriptor, options = copy.deepcopy(one_fault_model)
+    options.evaluation_options.number_octree_levels = 1
+    options.evaluation_options.mesh_extraction = False
+    options.evaluation_options.compute_scalar_gradient = False
+
+    baseline = compute_model(
+        copy.deepcopy(interpolation_input),
+        options,
+        copy.deepcopy(data_descriptor),
+    )
+
+    fault_points = interpolation_input.surface_points.sp_coords[:9]
+    finite_fault = FiniteFault(
+        center=tuple(np.mean(fault_points, axis=0)),
+        strike_radius=0.75,
+        dip_radius=0.75,
+    )
+    data_descriptor.stack_structure.faults_input_data = [
+        FaultsData.from_user_input(thickness=None, finite_fault=finite_fault),
+        None,
+        None,
+    ]
+
+    finite = compute_model(interpolation_input, options, data_descriptor)
+
+    finite_fault_output = finite.octrees_output[0].outputs[0].exported_fields
+    baseline_dependent = baseline.octrees_output[0].outputs[2].exported_fields.scalar_field
+    finite_dependent = finite.octrees_output[0].outputs[2].exported_fields.scalar_field
+    assert finite_fault_output.gx_field is not None
+    assert finite_fault_output.gy_field is not None
+    assert finite_fault_output.gz_field is not None
+    assert options.evaluation_options.compute_scalar_gradient is False
+    assert not np.allclose(finite_dependent, baseline_dependent)
+
+
+def test_finite_fault_flat_stack_matches_serial(one_fault_model, monkeypatch):
+    pytest.importorskip("pykeops")
+    interpolation_input, data_descriptor, options = copy.deepcopy(one_fault_model)
+    options.evaluation_options.number_octree_levels = 1
+    options.evaluation_options.mesh_extraction = False
+    options.evaluation_options.compute_scalar_gradient = False
+
+    fault_points = interpolation_input.surface_points.sp_coords[:9]
+    data_descriptor.stack_structure.faults_input_data = [
+        FaultsData.from_user_input(
+            thickness=None,
+            finite_fault=FiniteFault(
+                center=tuple(np.mean(fault_points, axis=0)),
+                strike_radius=0.75,
+                dip_radius=0.75,
+            ),
+        ),
+        None,
+        None,
+    ]
+
+    monkeypatch.setenv("GEMPY_FLAT_STACKS", "False")
+    serial = compute_model(
+        copy.deepcopy(interpolation_input),
+        options,
+        copy.deepcopy(data_descriptor),
+    )
+
+    original_use_pykeops = BackendTensor.use_pykeops
+    BackendTensor.use_pykeops = True
+    monkeypatch.setenv("GEMPY_FLAT_STACKS", "True")
+    try:
+        flat = compute_model(
+            copy.deepcopy(interpolation_input),
+            options,
+            copy.deepcopy(data_descriptor),
+        )
+    finally:
+        BackendTensor.use_pykeops = original_use_pykeops
+
+    serial_dependent = serial.octrees_output[0].outputs[2].exported_fields.scalar_field
+    flat_dependent = flat.octrees_output[0].outputs[2].exported_fields.scalar_field
+    # Dense and PyKeOps routes use different reduction orders.
+    assert np.allclose(flat_dependent, serial_dependent, atol=5e-3, rtol=1e-2)
+    assert flat.octrees_output[0].outputs[0].exported_fields.gx_field is not None
+    assert options.evaluation_options.compute_scalar_gradient is False

--- a/tests/test_common/test_api/test_input_validation.py
+++ b/tests/test_common/test_api/test_input_validation.py
@@ -1,13 +1,14 @@
 import pytest
 import numpy as np
 from gempy_engine.API.model.model_api import compute_model
-from gempy_engine.core.data import InterpolationOptions, SurfacePoints, Orientations, TensorsStructure
+from gempy_engine.core.data import FiniteFault, InterpolationOptions, SurfacePoints, Orientations, TensorsStructure
 from gempy_engine.core.data.engine_grid import EngineGrid, RegularGrid
 from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
 from gempy_engine.core.data.stack_relation_type import StackRelationType
 from gempy_engine.core.data.stacks_structure import StacksStructure
 from gempy_engine.core.data.interpolation_input import InterpolationInput
 from gempy_engine.core.data.kernel_classes.kernel_functions import AvailableKernelFunctions
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.core.exceptions import GemPyEngineInputError
 
 
@@ -127,3 +128,23 @@ def test_mismatched_surfaces_count(basic_input):
     with pytest.raises(GemPyEngineInputError, match="Total surfaces in StacksStructure"):
         compute_model(ii, options, dd)
 
+
+def test_finite_fault_requires_fault_stack(basic_input):
+    ii, options, dd = basic_input
+    dd.stack_structure.faults_input_data = [
+        FaultsData.from_user_input(
+            thickness=None,
+            finite_fault=FiniteFault(center=(0.5, 0.5, 0.5)),
+        )
+    ]
+
+    with pytest.raises(GemPyEngineInputError, match="requires a FAULT stack"):
+        compute_model(ii, options, dd)
+
+
+def test_fault_input_data_requires_one_entry_per_stack(basic_input):
+    ii, options, dd = basic_input
+    dd.stack_structure.faults_input_data = [None, None]
+
+    with pytest.raises(GemPyEngineInputError, match="one entry per stack"):
+        compute_model(ii, options, dd)


### PR DESCRIPTION
Integrates finite-fault support into fault stack interpolation paths, ensuring scalar gradients are enabled for finite faults and isolated stack handling for sequential and flat-stack modes. Adds validation for finite-fault definitions, scalar gradient dependencies, and fault-stack constraints. Updates tests, stack operations, and documentation for finite-fault wiring.